### PR TITLE
Added delete_on_update?()

### DIFF
--- a/lib/om/xml/term_value_operators.rb
+++ b/lib/om/xml/term_value_operators.rb
@@ -207,11 +207,15 @@ module OM::XML::TermValueOperators
     # template = opts.fetch(:template,nil)
     
     node = find_by_terms_and_value(*node_select)[node_index]
-    if new_value == "" || new_value == :delete
+    if delete_on_update?(node, new_value)
       node.remove
     else
       node.content = new_value
     end
+  end
+
+  def delete_on_update?(node, new_value)
+    new_value == "" || new_value == :delete
   end
   
   # def term_value_set(term_ref, query_opts, node_index, new_value)

--- a/spec/unit/term_value_operators_spec.rb
+++ b/spec/unit/term_value_operators_spec.rb
@@ -215,6 +215,27 @@ describe "OM::XML::TermValueOperators" do
       @article.term_values(:journal, :title_info).should == ['mork']
     end
 
+    describe "delete_on_update?" do
+
+      before(:each) do
+        att= {[:journal, :title_info]=>{"0"=>"york", "1"=>"mangle","2"=>"mork"}}
+        @article.update_values(att)
+        @article.term_values(:journal, :title_info).should == ['york', 'mangle', 'mork']
+      end
+
+      it "by default, setting to empty string deletes the node" do
+        @article.update_values({[:journal, :title_info]=>{"1"=>""}})
+        @article.term_values(:journal, :title_info).should == ['york', 'mork']
+      end
+
+      it "if delete_on_update? returns false, setting to empty string won't delete node" do
+        @article.stubs('delete_on_update?').returns(false)
+        @article.update_values({[:journal, :title_info]=>{"1"=>""}})
+        @article.term_values(:journal, :title_info).should == ['york', '', 'mork']
+      end
+
+    end
+
     it "should retain other child nodes when updating a text content term and shoud not append an additional text node but update text in place" do
       @article.term_values(:name,:name_content).should == ["Describes a person"]
       @article.update_values({[:name, :name_content]=>"Test text"})
@@ -259,7 +280,6 @@ describe "OM::XML::TermValueOperators" do
     it "should support adding attribute values" do
       pointer = [{:title_info=>0}, :language]
       test_val = "language value"
-debugger
       @article.term_values_append( 
         :parent_select => [{:title_info=>0}],
         :parent_index => 0,


### PR DESCRIPTION
Added delete_on_update?() to allow users to control whether setting to empty string deletes nodes
