### PR TITLE
When doing an update, OM should remove existing elements. Fixes #19

### DIFF
--- a/lib/om/xml/dynamic_node.rb
+++ b/lib/om/xml/dynamic_node.rb
@@ -70,10 +70,17 @@ module OM
       def val=(args)
         @document.ng_xml_will_change!
         new_values = term.sanitize_new_values(args.first)
+        existing_nodes = @document.find_by_xpath(xpath)
+        if existing_nodes.length > new_values.length
+          starting_index = new_values.length + 1
+          starting_index.upto(existing_nodes.size).each do |index|
+            @document.term_value_delete select: xpath, child_index: index
+          end
+        end
         new_values.keys.sort { |a,b| a.to_i <=> b.to_i }.each do |y|
           z = new_values[y]
 ## If we pass something that already has an index on it, we should be able to add it.
-          if @document.find_by_xpath(xpath)[y.to_i].nil? || y.to_i == -1
+          if existing_nodes[y.to_i].nil? || y.to_i == -1
             parent_pointer = parent ? parent.to_pointer : nil
             @document.term_values_append(:parent_select=> parent_pointer,:parent_index=>0,:template=>to_pointer,:values=>z)
           else

--- a/spec/unit/dynamic_node_spec.rb
+++ b/spec/unit/dynamic_node_spec.rb
@@ -156,6 +156,11 @@ describe "OM::XML::DynamicNode" do
         @article.should be_changed
       end
     
+      it "should remove extra nodes if fewer are given than currently exist" do
+        @article.journal.title_info = %W(one two three four five)
+        @article.journal.title_info = %W(six seven)
+        @article.journal.title_info.should == ["six", "seven"]
+      end
     end
   end
 end


### PR DESCRIPTION
The behavior occurs if the existing elements are more numerous than
the list being provided.
