### PR TITLE
Deprecate Hash values passed to Om::XML::Document#update_attributes. 

### DIFF
--- a/lib/om/xml/term_value_operators.rb
+++ b/lib/om/xml/term_value_operators.rb
@@ -29,7 +29,10 @@ module OM::XML::TermValueOperators
   # 
   # @param [Hash] params
   # @example
-  #   {[{":person"=>"0"}, "role", "text"]=>{"0"=>"role1", "1"=>"role2", "2"=>"role3"}, [{:person=>1}, :family_name]=>"Andronicus", [{"person"=>"1"},:given_name]=>["Titus"],[{:person=>1},:role,:text]=>["otherrole1","otherrole2"] }
+  #   {[{":person"=>"0"}, "role", "text"]=>["role1", "role2", "role3"], 
+  #     [{:person=>1}, :family_name]=>"Andronicus", 
+  #     [{"person"=>"1"},:given_name]=>["Titus"],
+  #     [{:person=>1},:role,:text]=>["otherrole1","otherrole2"] }
   def update_values(params={})
     # remove any terms from params that this datastream doesn't recognize    
     
@@ -44,6 +47,7 @@ module OM::XML::TermValueOperators
     result = params.dup
     
     params.each_pair do |term_pointer,new_values|
+      ActiveSupport::Deprecation.warn("Calling OM::Document#update_values with a hash of values to update (e.g. #{new_values}) is deprecated behavior. You ought to pass an array instead.  This behavior will be removed in OM 3.0.0", caller(3)) if new_values.kind_of? Hash
       pointer = OM.destringify(term_pointer)
       template_pointer = OM.pointers_to_flat_array(pointer,false)
       hn = OM::XML::Terminology.term_hierarchical_name(*pointer)


### PR DESCRIPTION
Fixes #22
