### PR TITLE
Ensure TemplateRegistry duplicates are using a separate copy of the template hash

### DIFF
--- a/lib/om/xml/template_registry.rb
+++ b/lib/om/xml/template_registry.rb
@@ -32,8 +32,8 @@
 
 class OM::XML::TemplateRegistry
 
-  def initialize
-    @templates = {}
+  def initialize(templates={})
+    @templates = templates.dup
   end
 
   # Define an XML template
@@ -127,6 +127,11 @@ class OM::XML::TemplateRegistry
     attach_node(:swap, target_node, :parent, node_type, *args, &block)
   end
   
+  def dup
+    result = self.class.new(@templates)
+    result
+  end
+
   def methods
     super + @templates.keys.collect { |k| k.to_s }
   end

--- a/spec/integration/subclass_terminology_spec.rb
+++ b/spec/integration/subclass_terminology_spec.rb
@@ -63,9 +63,18 @@ describe "Inherited terminology" do
 
       class ConcreteTerminology < AbstractTerminology
       end
+
+      class OtherConcreteTerminology < AbstractTerminology
+        define_template :foo do |xml, *args|
+          args.each { |arg|
+            xml.foo(arg)
+          }
+        end
+      end
     end
 
     after(:all) do
+      Object.send(:remove_const, :OtherConcreteTerminology)
       Object.send(:remove_const, :ConcreteTerminology)
       Object.send(:remove_const, :AbstractTerminology)
     end
@@ -79,6 +88,13 @@ describe "Inherited terminology" do
       it "should inherit templates" do
         subject.add_child_node subject.ng_xml.root, :creator, 'Test author', 'Primary' 
         subject.ng_xml.xpath('//pbcoreCreator/creatorRole[@source="PBCore creatorRole"]').text.should == "Primary"
+      end
+
+      it "should inherit but not extend its parent's templates" do
+        OtherConcreteTerminology.template_registry.should have_node_type(:creator)
+        OtherConcreteTerminology.template_registry.should have_node_type(:foo)
+        AbstractTerminology.template_registry.should_not have_node_type(:foo)
+        ConcreteTerminology.template_registry.should_not have_node_type(:foo)
       end
     end
   end


### PR DESCRIPTION
Subclasses are currently polluting the parent and all sibling classes with their templates
