### PR TITLE
Fixes == for comparing values of 2 dynamic nodes.

### DIFF
--- a/lib/om/xml/dynamic_node.rb
+++ b/lib/om/xml/dynamic_node.rb
@@ -119,7 +119,7 @@ module OM
       end
 
       def ==(other)
-        val == other
+        other == val
       end
 
       def eql?(other)

--- a/spec/unit/dynamic_node_spec.rb
+++ b/spec/unit/dynamic_node_spec.rb
@@ -161,6 +161,20 @@ describe "OM::XML::DynamicNode" do
         @article.journal.title_info = %W(six seven)
         @article.journal.title_info.should == ["six", "seven"]
       end
+
+      describe '==' do
+        it "returns true when values of dynamic nodes are equal." do
+          @article.name(0).last_name = "Steven"
+          @article.name(0).first_name = "Steven"
+          (@article.name(0).last_name == @article.name(0).first_name).should == true
+        end
+
+        it 'returns false when values of dynamic nodes are not equal.' do
+          @article.name(0).first_name = "Horatio"
+          @article.name(0).last_name = "Hogginobble"
+          (@article.name(0).last_name == @article.name(0).first_name).should == false
+        end
+      end 
     end
   end
 end


### PR DESCRIPTION
### Example:

``` ruby
class Foo
  include OM::XML::Document

  set_terminology do |t|
      t.root(:path => 'foo')
      t.bar
      t.bar2
  end

  def self.xml_template
      Nokogiri::XML.parse("<foo/>")
  end
end

f = Foo.new
f.foo.bar = "a"
f.foo.bar2 = "a"

# before
f.foo.bar == f.foo.bar2
# => false

# after
f.foo.bar == f.foo.bar2
# => true
```
