### PR TITLE
Use HTTPS URLs for RubyGems

### DIFF
--- a/GETTING_STARTED.textile
+++ b/GETTING_STARTED.textile
@@ -30,7 +30,7 @@ cd omtest
 Using whichever editor you prefer, create a file (in omtest directory) called Gemfile with the following contents:
 
 <pre>
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem 'om'
 </pre>
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 

--- a/History.textile
+++ b/History.textile
@@ -1,3 +1,5 @@
+  2014-09-11: Use HTTPS URLs for RubyGems [Michael Slone]
+
 h3. 3.1.0 (17 Jul 2014)
   2014-07-17: Bump solrizer version to ~> 3.3 [Justin Coyne]
 

--- a/gemfiles/gemfile.rails3
+++ b/gemfiles/gemfile.rails3
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec :path=>"../"
 

--- a/gemfiles/gemfile.rails4
+++ b/gemfiles/gemfile.rails4
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec :path=>"../"
 


### PR DESCRIPTION
This modifies Gemfiles in this repository to use HTTPS URLs (instead of HTTP) for RubyGems.
