### PR TITLE
Changing RSpec assertions from .should() to the newer, prefered expect().to()

### DIFF
--- a/spec/integration/differentiated_elements_spec.rb
+++ b/spec/integration/differentiated_elements_spec.rb
@@ -30,10 +30,10 @@ describe "use the root element as a member of the proxy address" do
   end
 
   it "should pull out all occurences of the_thing_we_want in the relevant_container" do
-    subject.relevant_container.the_thing_we_want.should == ["1", "2"]
+    expect(subject.relevant_container.the_thing_we_want).to eq ["1", "2"]
   end
 
   it "should only pull out the_thing_we_want at the root level" do
-    subject.the_thing_we_want.should == ["2"]
+    expect(subject.the_thing_we_want).to eq ["2"]
   end
 end

--- a/spec/integration/element_value_spec.rb
+++ b/spec/integration/element_value_spec.rb
@@ -53,39 +53,39 @@ EOF
 end
 
   it "should handle single-element terms correctly" do
-    subject.elementA.should == ["valA"]
+    expect(subject.elementA).to eq ["valA"]
   end
 
   it "should handle term paths" do
-    subject.elC.should == ["valC"]
+    expect(subject.elC).to eq ["valC"]
   end
 
   it "should handle multiple-element, terms with paths correctly" do
-    subject.elB.should == ["valB1", "valB2"]
+    expect(subject.elB).to eq ["valB1", "valB2"]
   end
 
   it "should handle terms that require specific attributes" do
-    subject.elementC.should == ["valC"]
+    expect(subject.elementC).to eq ["valC"]
   end
 
   it "should handle" do
-    subject.here.length.should == 1
-    subject.here.first.split(/\W/).should include('123', '456')
+    expect(subject.here.length).to eq 1
+    expect(subject.here.first.split(/\W/)).to include('123', '456')
   end
 
   it "should handle missing terms" do
-    subject.there.should be_empty
+    expect(subject.there).to be_empty
   end
 
   it "should handle element  value given the absence of a specific attribute" do
-    subject.elementD.should == ["valD1"]
-    subject.no_attrib.should == ["valB1"]
+    expect(subject.elementD).to eq ["valD1"]
+    expect(subject.no_attrib).to eq ["valB1"]
   end
 
   it "should handle OM terms for an attribute value" do
-    subject.elementB.my_attr.should == ["vole"]
-    subject.alternate.should == ["vole"]
-    subject.another.should == ["vole"]
-    subject.animal_attrib.should include("vole", "seagull")
+    expect(subject.elementB.my_attr).to eq ["vole"]
+    expect(subject.alternate).to eq ["vole"]
+    expect(subject.another).to eq ["vole"]
+    expect(subject.animal_attrib).to include("vole", "seagull")
   end
 end

--- a/spec/integration/proxies_and_ref_spec.rb
+++ b/spec/integration/proxies_and_ref_spec.rb
@@ -68,21 +68,21 @@ describe "an example with :proxy and :ref" do
 
     describe "image" do
       it "should have the right proxy terms" do
-        subject.ead_fedora_pid.should include "hypatia:ead_file_asset_fixture"
-        subject.ead_ds_label.should include "my_ead.xml"
-        subject.ead_size.should include "47570"
-        subject.ead_md5.should include "123"
-        subject.ead_sha1.should include "456"
+        expect(subject.ead_fedora_pid).to include "hypatia:ead_file_asset_fixture"
+        expect(subject.ead_ds_label).to include "my_ead.xml"
+        expect(subject.ead_size).to include "47570"
+        expect(subject.ead_md5).to include "123"
+        expect(subject.ead_sha1).to include "456"
       end
     end
 
     describe "ead" do
       it "should have the right proxy terms" do
-        subject.image_fedora_pid.should include "hypatia:coll_img_file_asset_fixture"
-        subject.image_ds_label.should include "my_image.jpg"
-        subject.image_size.should include "302080"
-        subject.image_md5.should include "789"
-        subject.image_sha1.should include "666"
+        expect(subject.image_fedora_pid).to include "hypatia:coll_img_file_asset_fixture"
+        expect(subject.image_ds_label).to include "my_image.jpg"
+        expect(subject.image_size).to include "302080"
+        expect(subject.image_md5).to include "789"
+        expect(subject.image_sha1).to include "666"
       end
     end
   end

--- a/spec/integration/querying_documents_spec.rb
+++ b/spec/integration/querying_documents_spec.rb
@@ -11,31 +11,26 @@ describe "Rspec tests for QUERYING_DOCUMENTS.textile" do
   end
 
   it "xpath_for()" do
-    @term.xpath_for(:name).should == 
-      '//oxns:name'
-    @term.xpath_for(:person).should == 
-      '//oxns:name[@type="personal"]'
-    @term.xpath_for(:organization).should == 
-      '//oxns:name[@type="corporate"]'
-    @term.xpath_for(:person, :first_name).should ==
-      '//oxns:name[@type="personal"]/oxns:namePart[@type="given"]'
-    @term.xpath_for(:journal, :issue, :pages, :start).should ==
-      '//oxns:relatedItem[@type="host"]/oxns:part/oxns:extent[@unit="pages"]/oxns:start'
+    expect(@term.xpath_for(:name)).to eq '//oxns:name'
+    expect(@term.xpath_for(:person)).to eq '//oxns:name[@type="personal"]'
+    expect(@term.xpath_for(:organization)).to eq '//oxns:name[@type="corporate"]'
+    expect(@term.xpath_for(:person, :first_name)).to eq '//oxns:name[@type="personal"]/oxns:namePart[@type="given"]'
+    expect(@term.xpath_for(:journal, :issue, :pages, :start)).to eq '//oxns:relatedItem[@type="host"]/oxns:part/oxns:extent[@unit="pages"]/oxns:start'
   end
 
   it "term_values()" do
-    @doc.term_values(:person, :first_name).should == ["GIVEN NAMES", "Siddartha"]
-    @doc.term_values(:person, :last_name).should == ["FAMILY NAME", "Gautama"]
-    @doc.term_values(:organization, :namePart).should == ['NSF']
-    @doc.term_values(:journal, :issue, :pages, :start).should == ['195']
-    @doc.term_values(:journal, :title_info, :main_title).should == ["TITLE OF HOST JOURNAL"]
+    expect(@doc.term_values(:person, :first_name)).to eq ["GIVEN NAMES", "Siddartha"]
+    expect(@doc.term_values(:person, :last_name)).to eq ["FAMILY NAME", "Gautama"]
+    expect(@doc.term_values(:organization, :namePart)).to eq ['NSF']
+    expect(@doc.term_values(:journal, :issue, :pages, :start)).to eq ['195']
+    expect(@doc.term_values(:journal, :title_info, :main_title)).to eq ["TITLE OF HOST JOURNAL"]
   end
 
   it "xpath_for(): relative vs absolute" do
     xp_rel = '//oxns:titleInfo/oxns:title'
     xp_abs = '//oxns:mods/oxns:titleInfo/oxns:title'
-    @term.xpath_for(       :title_info, :main_title).should == xp_rel
-    @term.xpath_for(:mods, :title_info, :main_title).should == xp_abs
+    expect(@term.xpath_for(       :title_info, :main_title)).to eq xp_rel
+    expect(@term.xpath_for(:mods, :title_info, :main_title)).to eq xp_abs
   end
 
   it "term_values(): relative vs absolute" do
@@ -45,16 +40,16 @@ describe "Rspec tests for QUERYING_DOCUMENTS.textile" do
       "TITLE OF HOST JOURNAL",
     ]
     xp_abs = '//oxns:mods/oxns:titleInfo/oxns:title'
-    @doc.term_values(       :title_info, :main_title).should == exp
-    @doc.term_values(:mods, :title_info, :main_title).should == exp[0..1]
+    expect(@doc.term_values(       :title_info, :main_title)).to eq exp
+    expect(@doc.term_values(:mods, :title_info, :main_title)).to eq exp[0..1]
   end
 
   it "find_by_terms()" do
     exp_xml_role  = '<role><roleTerm authority="marcrelator" type="text">funder</roleTerm></role>'
     exp_xml_start = '<start>195</start>'
-    @doc.find_by_terms(:organization, :role).class.should == Nokogiri::XML::NodeSet
-    @doc.find_by_terms(:organization, :role).to_xml.should be_equivalent_to exp_xml_role
-    @doc.find_by_terms(:journal, :issue, :pages, :start).to_xml.should == exp_xml_start
+    expect(@doc.find_by_terms(:organization, :role).class).to eq Nokogiri::XML::NodeSet
+    expect(@doc.find_by_terms(:organization, :role).to_xml).to be_equivalent_to exp_xml_role
+    expect(@doc.find_by_terms(:journal, :issue, :pages, :start).to_xml).to eq exp_xml_start
   end
 
   it "find_by_terms() error" do
@@ -63,10 +58,8 @@ describe "Rspec tests for QUERYING_DOCUMENTS.textile" do
   end
 
   it "proxies" do
-    @term.xpath_for(:title).should ==
-      '//oxns:titleInfo/oxns:title'
-    @term.xpath_for(:journal_title)
-      '//oxns:relatedItem[@type="host"]/oxns:titleInfo/oxns:title'
+    expect(@term.xpath_for(:title)).to eq '//oxns:titleInfo/oxns:title'
+    expect(@term.xpath_for(:journal_title)).to eq'//oxns:relatedItem[@type="host"]/oxns:titleInfo/oxns:title'
   end
 
 end

--- a/spec/integration/rights_metadata_integration_example_spec.rb
+++ b/spec/integration/rights_metadata_integration_example_spec.rb
@@ -66,10 +66,10 @@ describe "OM::XML::Accessors" do
   describe "update_properties" do
     it "should update the declared properties" do
       skip "nesting is too deep..."
-      @sample.retrieve(*[:edit_access, :machine, :person]).length.should == 0
-      @sample.update_properties([:edit_access, :machine, :person]=>"user id").should == {"edit_access_machine_person"=>{"-1"=>"user id"}}
-      @sample.retrieve(*[:edit_access, :machine, :person]).length.should == 1
-      @sample.retrieve(*[:edit_access, :machine, :person]).first.text.should == "user id"
+      expect(@sample.retrieve(*[:edit_access, :machine, :person]).length).to eq 0
+      expect(@sample.update_properties([:edit_access, :machine, :person]=>"user id")).to eq({"edit_access_machine_person"=>{"-1"=>"user id"}})
+      expect(@sample.retrieve(*[:edit_access, :machine, :person]).length).to eq  1
+      expect(@sample.retrieve(*[:edit_access, :machine, :person]).first.text).to eq "user id"
     end
   end
   

--- a/spec/integration/selective_querying_spec.rb
+++ b/spec/integration/selective_querying_spec.rb
@@ -83,7 +83,7 @@ describe "Selecting nodes based on (a) position in hierarchy and (b) attributes"
       [ 'inner_note_a',     %w(                    i3a i4a) ],
       [ 'inner_note_not_a', %w(              i1 i2        ) ],
     ]
-    tests.each { |meth, exp| @doc.send(meth).should == exp }
+    tests.each { |meth, exp| expect(@doc.send(meth)).to eq exp }
   end
 
 end

--- a/spec/integration/serialization_spec.rb
+++ b/spec/integration/serialization_spec.rb
@@ -35,16 +35,16 @@ EOF
     subject { datastream } 
     describe "reading  values" do
       it "should deserialize date" do
-        subject.my_date.should == [Date.parse('2012-10-30')]
+        expect(subject.my_date).to eq [Date.parse('2012-10-30')]
       end
       it "should deserialize time" do
-        subject.my_time.should == [DateTime.parse('2012-10-30T12:22:33Z')]
+        expect(subject.my_time).to eq [DateTime.parse('2012-10-30T12:22:33Z')]
       end
       it "should deserialize ints" do
-        subject.my_int.should == [7]
+        expect(subject.my_int).to eq [7]
       end
       it "should deserialize boolean" do
-        subject.active.should == [true]
+        expect(subject.active).to eq [true]
       end
     end
     describe "Writing to xml" do
@@ -52,7 +52,7 @@ EOF
         context "with a valid time" do
           subject { datastream.to_xml }
           before { datastream.my_time = [DateTime.parse('2011-01-30T03:45:15Z')] }
-          it { should be_equivalent_to '<?xml version="1.0"?>
+          it { is_expected.to be_equivalent_to '<?xml version="1.0"?>
            <outer outerId="hypatia:outer" type="outer type">
              <my_date>2012-10-30</my_date>
              <my_time>2011-01-30T03:45:15Z</my_time>
@@ -77,7 +77,7 @@ EOF
         context "with a valid date" do
 
           before { datastream.my_date = [Date.parse('2012-09-22')] }
-          it { should be_equivalent_to '<?xml version="1.0"?>
+          it { is_expected.to be_equivalent_to '<?xml version="1.0"?>
            <outer outerId="hypatia:outer" type="outer type">
              <my_date>2012-09-22</my_date>
              <my_time>2012-10-30T12:22:33Z</my_time>
@@ -89,7 +89,7 @@ EOF
 
       it "should serialize ints" do
         subject.my_int = [9]
-        subject.to_xml.should be_equivalent_to '<?xml version="1.0"?>
+        expect(subject.to_xml).to be_equivalent_to '<?xml version="1.0"?>
          <outer outerId="hypatia:outer" type="outer type">
            <my_date>2012-10-30</my_date>
            <my_time>2012-10-30T12:22:33Z</my_time>
@@ -99,7 +99,7 @@ EOF
       end
       it "should serialize boolean" do
         subject.active = [false]
-        subject.to_xml.should be_equivalent_to '<?xml version="1.0"?>
+        expect(subject.to_xml).to be_equivalent_to '<?xml version="1.0"?>
          <outer outerId="hypatia:outer" type="outer type">
            <my_date>2012-10-30</my_date>
            <my_time>2012-10-30T12:22:33Z</my_time>
@@ -122,19 +122,19 @@ EOF
     end
     describe "reading  values" do
       it "should deserialize date" do
-        subject.my_date.should == [nil]
+        expect(subject.my_date).to eq [nil]
       end
       it "should deserialize ints" do
-        subject.my_int.should == [nil]
+        expect(subject.my_int).to eq [nil]
       end
       it "should deserialize bools" do
-        subject.active.should == [false]
+        expect(subject.active).to eq [false]
       end
     end
     describe "Writing to xml" do
       it "should serialize date" do
         subject.my_date = [Date.parse('2012-09-22')]
-        subject.to_xml.should be_equivalent_to '<?xml version="1.0"?>
+        expect(subject.to_xml).to be_equivalent_to '<?xml version="1.0"?>
          <outer outerId="hypatia:outer" type="outer type">
            <my_date>2012-09-22</my_date>
            <my_int></my_int>
@@ -143,7 +143,7 @@ EOF
       end
       it "should serialize ints" do
         subject.my_int = [9]
-        subject.to_xml.should be_equivalent_to '<?xml version="1.0"?>
+        expect(subject.to_xml).to be_equivalent_to '<?xml version="1.0"?>
          <outer outerId="hypatia:outer" type="outer type">
            <my_date></my_date>
            <my_int>9</my_int>
@@ -152,7 +152,7 @@ EOF
       end
       it "should serialize booleans" do
         subject.active = [true]
-        subject.to_xml.should be_equivalent_to '<?xml version="1.0"?>
+        expect(subject.to_xml).to be_equivalent_to '<?xml version="1.0"?>
          <outer outerId="hypatia:outer" type="outer type">
            <my_date></my_date>
            <my_int></my_int>
@@ -163,7 +163,7 @@ EOF
         subject.my_int = [nil]
         subject.my_date = [nil]
         subject.active = [nil]
-        subject.to_xml.should be_equivalent_to '<?xml version="1.0"?>
+        expect(subject.to_xml).to be_equivalent_to '<?xml version="1.0"?>
          <outer outerId="hypatia:outer" type="outer type">
          </outer>'
       end

--- a/spec/integration/set_reentrant_terminology_spec.rb
+++ b/spec/integration/set_reentrant_terminology_spec.rb
@@ -21,7 +21,7 @@ describe "calling set_terminology more than once" do
     end
 
     it "can get foo" do
-      subject.foo.should == ['fooval']
+      expect(subject.foo).to eq ['fooval']
     end
 
     it "cannot get bar" do
@@ -51,7 +51,7 @@ describe "calling set_terminology more than once" do
     end
 
     it "can now get bar" do
-      subject.bar.should == ['barval']
+      expect(subject.bar).to eq ['barval']
     end
 
   end
@@ -80,11 +80,11 @@ describe "calling set_terminology more than once" do
     end
 
     it "can get foo" do
-      subject.foo.should == ['fooval']
+      expect(subject.foo).to eq ['fooval']
     end
 
     it "can get bar" do
-      subject.bar.should == ['barval']
+      expect(subject.bar).to eq ['barval']
     end
 
   end
@@ -122,11 +122,11 @@ describe "calling set_terminology more than once" do
     end
 
     it "can get foo" do
-      subject.foo.should == ['fooval']
+      expect(subject.foo).to eq ['fooval']
     end
 
     it "can get bar" do
-      subject.bar.should == ['barval']
+      expect(subject.bar).to eq ['barval']
     end
 
   end

--- a/spec/integration/subclass_terminology_spec.rb
+++ b/spec/integration/subclass_terminology_spec.rb
@@ -31,12 +31,12 @@ describe "Inherited terminology" do
 
       it "should inherit terminology" do
         subject.foo = "Test value"
-        subject.foo.should == ["Test value"]
+        expect(subject.foo).to eq ["Test value"]
       end
 
       it "should have extended terminology" do
         subject.bar = "Test value"
-        subject.bar.should == ["Test value"]
+        expect(subject.bar).to eq ["Test value"]
       end
     end
 
@@ -48,7 +48,7 @@ describe "Inherited terminology" do
 
       it "should have terminology" do
         subject.foo = "Test value"
-        subject.foo.should == ["Test value"]
+        expect(subject.foo).to eq ["Test value"]
       end
 
       it "should not have extended terminology" do
@@ -99,14 +99,14 @@ describe "Inherited terminology" do
 
       it "should inherit templates" do
         subject.add_child_node subject.ng_xml.root, :creator, 'Test author', 'Primary' 
-        subject.ng_xml.xpath('//pbcoreCreator/creatorRole[@source="PBCore creatorRole"]').text.should == "Primary"
+        expect(subject.ng_xml.xpath('//pbcoreCreator/creatorRole[@source="PBCore creatorRole"]').text).to eq "Primary"
       end
 
       it "should inherit but not extend its parent's templates" do
-        OtherConcreteTerminology.template_registry.should have_node_type(:creator)
-        OtherConcreteTerminology.template_registry.should have_node_type(:foo)
-        AbstractTerminology.template_registry.should_not have_node_type(:foo)
-        ConcreteTerminology.template_registry.should_not have_node_type(:foo)
+        expect(OtherConcreteTerminology.template_registry).to have_node_type(:creator)
+        expect(OtherConcreteTerminology.template_registry).to have_node_type(:foo)
+        expect(AbstractTerminology.template_registry).not_to have_node_type(:foo)
+        expect(ConcreteTerminology.template_registry).not_to have_node_type(:foo)
       end
     end
   end

--- a/spec/integration/xpathy_stuff_spec.rb
+++ b/spec/integration/xpathy_stuff_spec.rb
@@ -51,11 +51,11 @@ describe "an example of xpath-y stuff, also using :proxy and :ref and namespaces
     end
 
     it "should have a content term" do
-      subject.content.first.should =~ /content/
+      expect(subject.content.first).to match /content/
     end
 
     it "should have an html term" do
-      subject.html.first.should =~ /html/
+      expect(subject.html.first).to match /html/
     end
 
 
@@ -121,14 +121,14 @@ describe "an example of xpath-y stuff, also using :proxy and :ref and namespaces
 
     it "should have the terms :author_given and :author_family to get the author name" do
       skip "This doesn't seem to work?"
-      subject.author_given.should include("Mary")
-      subject.author_family.should include("Pickral")
+      expect(subject.author_given).to include("Mary")
+      expect(subject.author_family).to include("Pickral")
     end
 
     it "should have the terms :advisor_given and :advisor_family to get the advisor name" do
       skip "This doesn't seem to work?"
-      subject.advisor_given.should include("David")
-      subject.advisor_family.should include("Small")
+      expect(subject.advisor_given).to include("David")
+      expect(subject.advisor_family).to include("Small")
     end
 
   end
@@ -185,19 +185,19 @@ describe "an example of xpath-y stuff, also using :proxy and :ref and namespaces
     end
 
     it "should give a creator value" do
-      subject.creator.should include "David Small"
+      expect(subject.creator).to include "David Small"
     end
 
     it "should give a repository value" do
-      subject.repository.should include "Graphic Novel Repository"
+      expect(subject.repository).to include "Graphic Novel Repository"
     end
 
     it "should have a person term 'for more generic xml'" do
-      subject.person.should include "David Small"
+      expect(subject.person).to include "David Small"
     end
 
     it "should have a corporate term 'for more generic xml'" do
-      subject.corporate.should include "Graphic Novel Repository"
+      expect(subject.corporate).to include "Graphic Novel Repository"
     end
   end
 end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -13,17 +13,17 @@ describe "OM::XML::Container" do
   }
 
   it "should add .ng_xml accessor" do
-    subject.should respond_to(:ng_xml)
-    subject.should respond_to(:ng_xml=)    
+    expect(subject).to respond_to(:ng_xml)
+    expect(subject).to respond_to(:ng_xml=)
   end
 
   it "should initialize" do
-    ContainerTest.new.ng_xml.should be_a_kind_of Nokogiri::XML::Document
+    expect(ContainerTest.new.ng_xml).to be_a_kind_of Nokogiri::XML::Document
   end
   
   describe "new" do
     it "should populate ng_xml with an instance of Nokogiri::XML::Document" do
-      subject.ng_xml.class.should == Nokogiri::XML::Document
+      expect(subject.ng_xml.class).to eq Nokogiri::XML::Document
     end
   end
 
@@ -31,18 +31,18 @@ describe "OM::XML::Container" do
     it "should accept a String, parse it and store it in .ng_xml" do
       Nokogiri::XML::Document.should_receive(:parse).and_return("parsed xml")
       container1 = ContainerTest.from_xml("<foo><bar>1</bar></foo>")
-      container1.ng_xml.should == "parsed xml"
+      expect(container1.ng_xml).to eq "parsed xml"
     end
     it "should accept a File, parse it and store it in .ng_xml" do
       file = fixture(File.join("mods_articles", "hydrangea_article1.xml"))
       Nokogiri::XML::Document.should_receive(:parse).and_return("parsed xml")
       container1 = ContainerTest.from_xml(file)
-      container1.ng_xml.should == "parsed xml"
+      expect(container1.ng_xml).to eq "parsed xml"
     end
     it "should accept Nokogiri nodes as input and leave them as-is" do
       parsed_xml = Nokogiri::XML::Document.parse("<foo><bar>1</bar></foo>")
       container1 = ContainerTest.from_xml(parsed_xml)
-      container1.ng_xml.should == parsed_xml
+      expect(container1.ng_xml).to eq parsed_xml
     end
   end
   
@@ -61,7 +61,7 @@ describe "OM::XML::Container" do
     
     it 'should accept an optional Nokogiri::XML Document as an argument and insert its fields into that (functional test)' do
       doc = Nokogiri::XML::Document.parse("<test_xml/>")
-      subject.to_xml(doc).should == "<?xml version=\"1.0\"?>\n<test_xml>\n  <foo>\n    <bar>1</bar>\n  </foo>\n</test_xml>\n"
+      expect(subject.to_xml(doc)).to eq "<?xml version=\"1.0\"?>\n<test_xml>\n  <foo>\n    <bar>1</bar>\n  </foo>\n</test_xml>\n"
     end
     
     it 'should add to root of Nokogiri::XML::Documents, but add directly to the elements if a Nokogiri::XML::Node is passed in' do
@@ -72,7 +72,7 @@ describe "OM::XML::Container" do
       el = Nokogiri::XML::Node.new("test_element", Nokogiri::XML::Document.new)
       doc.root.should_receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
       el.should_receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
-      subject.to_xml(doc).should 
+      subject.to_xml(doc).should
       subject.to_xml(el)
     end
   end

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -75,14 +75,14 @@ describe "OM::XML::Document" do
   end
   
   it "should automatically include the necessary modules" do
-    DocumentTest.included_modules.should include(OM::XML::Container)
-    DocumentTest.included_modules.should include(OM::XML::TermValueOperators)
-    DocumentTest.included_modules.should include(OM::XML::Validation)
+    expect(DocumentTest.included_modules).to include(OM::XML::Container)
+    expect(DocumentTest.included_modules).to include(OM::XML::TermValueOperators)
+    expect(DocumentTest.included_modules).to include(OM::XML::Validation)
   end
   
   describe ".ox_namespaces" do
     it "should merge terminology namespaces with document namespaces" do
-      @fixturemods.ox_namespaces.should == {"oxns"=>"http://www.loc.gov/mods/v3", "xmlns:ns2"=>"http://www.w3.org/1999/xlink", "xmlns:xsi"=>"http://www.w3.org/2001/XMLSchema-instance", "xmlns:ns3"=>"http://www.loc.gov/mods/v3", "xmlns"=>"http://www.loc.gov/mods/v3"}
+      expect(@fixturemods.ox_namespaces).to eq({"oxns"=>"http://www.loc.gov/mods/v3", "xmlns:ns2"=>"http://www.w3.org/1999/xlink", "xmlns:xsi"=>"http://www.w3.org/2001/XMLSchema-instance", "xmlns:ns3"=>"http://www.loc.gov/mods/v3", "xmlns"=>"http://www.loc.gov/mods/v3"})
     end
   end
   
@@ -90,10 +90,10 @@ describe "OM::XML::Document" do
   describe ".find_by_terms_and_value" do
     it "should fail gracefully if you try to look up nodes for an undefined property" do
       skip "better to get an informative error?"
-      @fixturemods.find_by_terms_and_value(:nobody_home).should == []
+      expect(@fixturemods.find_by_terms_and_value(:nobody_home)).to eq []
     end
     it "should use Nokogiri to retrieve a NodeSet corresponding to the term pointers" do
-      @mods_article.find_by_terms_and_value( :person ).length.should == 2
+      expect(@mods_article.find_by_terms_and_value( :person ).length).to eq 2
     end
 
     it "should allow you to search by term pointer" do
@@ -114,48 +114,48 @@ describe "OM::XML::Document" do
   end
   describe ".find_by_terms" do
     it "should use Nokogiri to retrieve a NodeSet corresponding to the combination of term pointers and array/nodeset indexes" do
-      @mods_article.find_by_terms( :person ).length.should == 2
-      @mods_article.find_by_terms( {:person=>1} ).first.should == @mods_article.ng_xml.xpath('//oxns:name[@type="personal"][2]', "oxns"=>"http://www.loc.gov/mods/v3").first
-      @mods_article.find_by_terms( {:person=>1}, :first_name ).class.should == Nokogiri::XML::NodeSet
-      @mods_article.find_by_terms( {:person=>1}, :first_name ).first.text.should == "Siddartha"
+      expect(@mods_article.find_by_terms( :person ).length).to eq 2
+      expect(@mods_article.find_by_terms( {:person=>1} ).first).to eq @mods_article.ng_xml.xpath('//oxns:name[@type="personal"][2]', "oxns"=>"http://www.loc.gov/mods/v3").first
+      expect(@mods_article.find_by_terms( {:person=>1}, :first_name ).class).to eq Nokogiri::XML::NodeSet
+      expect(@mods_article.find_by_terms( {:person=>1}, :first_name ).first.text).to eq "Siddartha"
     end
     it "should find a NodeSet where a terminology attribute has been set to :none" do
-      @mods_article.find_by_terms( {:person=>1}, :person_id).first.text.should == "123987"
+      expect(@mods_article.find_by_terms( {:person=>1}, :person_id).first.text).to eq "123987"
     end
     it "should support accessors whose relative_xpath is a lookup array instead of an xpath string" do
       # skip "this only impacts scenarios where we want to display & edit"
-      DocumentTest.terminology.retrieve_term(:title_info, :language).path.should == {:attribute=>"lang"}
+      expect(DocumentTest.terminology.retrieve_term(:title_info, :language).path).to eq({:attribute=>"lang"})
       # @sample.retrieve( :title, 1 ).first.text.should == "Artikkelin otsikko Hydrangea artiklan 1"
-      @mods_article.find_by_terms( {:title_info=>1}, :language ).first.text.should == "finnish"
+      expect(@mods_article.find_by_terms( {:title_info=>1}, :language ).first.text).to eq "finnish"
     end
     
     it "should support xpath queries as the pointer" do
-      @mods_article.find_by_terms('//oxns:name[@type="personal"][1]/oxns:namePart[1]').first.text.should == "FAMILY NAME"
+      expect(@mods_article.find_by_terms('//oxns:name[@type="personal"][1]/oxns:namePart[1]').first.text).to eq "FAMILY NAME"
     end
     
     it "should return nil if the xpath fails to generate" do
       skip "Can't decide if it's better to return nil or raise an error.  Choosing informative errors for now."
-      @mods_article.find_by_terms( {:foo=>20}, :bar ).should == nil
+      expect(@mods_article.find_by_terms( {:foo=>20}, :bar )).to eq nil
     end
     
     it "should support terms that point to attributes instead of nodes" do
-      @mods_article.find_by_terms( {:title_info=>1}, :language ).first.text.should == "finnish"
+      expect(@mods_article.find_by_terms( {:title_info=>1}, :language ).first.text).to eq "finnish"
     end
 
     it "should support xpath queries as the pointer" do
-      @mods_article.find_by_terms('//oxns:name[@type="personal"][1]/oxns:namePart[1]').first.text.should == "FAMILY NAME"
+      expect(@mods_article.find_by_terms('//oxns:name[@type="personal"][1]/oxns:namePart[1]').first.text).to eq "FAMILY NAME"
     end
   end
   
   describe "node_exists?" do
     it "should return true if any nodes are found" do
-      @mods_article.node_exists?( {:person=>1}, :first_name).should be true
+      expect(@mods_article.node_exists?( {:person=>1}, :first_name)).to be true
     end
     it "should return false if no nodes are found" do
-      @mods_article.node_exists?( {:person=>8}, :first_name ).should be false
+      expect(@mods_article.node_exists?( {:person=>8}, :first_name )).to be false
     end
     it "should support xpath queries" do
-      @mods_article.node_exists?('//oxns:name[@type="personal"][1]/oxns:namePart[1]').should be true
+      expect(@mods_article.node_exists?('//oxns:name[@type="personal"][1]/oxns:namePart[1]')).to be true
     end
   end
    

--- a/spec/unit/dynamic_node_spec.rb
+++ b/spec/unit/dynamic_node_spec.rb
@@ -26,26 +26,26 @@ describe "OM::XML::DynamicNode" do
 
     it "should create templates for dynamic nodes" do
       @sample.creator = "Foo"
-      @sample.creator.should == ['Foo']
+      expect(@sample.creator).to eq ['Foo']
     end
     it "should create templates for dynamic nodes with multiple values" do
       @sample.creator = ["Foo", "Bar"]
-      @sample.creator.should == ['Foo', 'Bar']
+      expect(@sample.creator).to eq ['Foo', 'Bar']
     end
 
     it "should create templates for dynamic nodes with empty string values" do
       @sample.creator = ['']
-      @sample.creator.should == ['']
+      expect(@sample.creator).to eq ['']
     end
 
     it "should create templates for plain nodes" do
       @sample.foo = ['in a galaxy far far away']
-      @sample.foo.should == ['in a galaxy far far away']
+      expect(@sample.foo).to eq ['in a galaxy far far away']
     end
 
     it "should create templates for dynamic nodes with a period in the element name" do
       @sample.date_created = ['A long time ago']
-      @sample.date_created.should == ['A long time ago']
+      expect(@sample.date_created).to eq ['A long time ago']
     end
 
     it "checks inequality" do
@@ -66,23 +66,23 @@ describe "OM::XML::DynamicNode" do
       it "should return build an array of values from the nodeset corresponding to the given term" do
         expected_values = ["Berners-Lee", "Jobs", "Wozniak", "Klimt"]
         result = @sample.person.last_name
-        result.length.should == expected_values.length
-        expected_values.each {|v| result.should include(v)}
+        expect(result.length).to eq expected_values.length
+        expected_values.each {|v| expect(result).to include(v)}
       end
 
       it "should be able to set first level elements" do
         @article.abstract = "My Abstract"
-        @article.abstract.should == ["My Abstract"]
+        expect(@article.abstract).to eq ["My Abstract"]
       end
 
       it "should be able to set first level elements that are arrays" do
         @article.abstract = ["My Abstract", "two"]
-        @article.abstract.should == ["My Abstract", 'two']
+        expect(@article.abstract).to eq ["My Abstract", 'two']
       end
 
       it "should delegate all methods (i.e. to_s, first, etc.) to the found array" do
-        @article.person.last_name.to_s.should == ["FAMILY NAME", "Gautama"].to_s
-        @article.person.last_name.first.should == "FAMILY NAME"
+        expect(@article.person.last_name.to_s).to eq ["FAMILY NAME", "Gautama"].to_s
+        expect(@article.person.last_name.first).to eq "FAMILY NAME"
       end
 
       it "should respond_to? things an array can do" do
@@ -92,60 +92,60 @@ describe "OM::XML::DynamicNode" do
       it "should delegate with blocks to the found array" do
         arr = []
         @article.person.last_name.each{|x| arr << x}
-        arr.should == ["FAMILY NAME", "Gautama"]
+        expect(arr).to eq ["FAMILY NAME", "Gautama"]
       end
 
 
       describe "setting attributes" do
         it "when they exist" do
           @article.title_info(0).main_title.main_title_lang = "ger"
-          @article.title_info(0).main_title.main_title_lang.should == ["ger"]
+          expect(@article.title_info(0).main_title.main_title_lang).to eq ["ger"]
         end
         it "when they don't exist" do
           title = @article.title_info(0)
           title.language = "rus"
-          @article.title_info(0).language.should == ["rus"]
+          expect(@article.title_info(0).language).to eq ["rus"]
         end
 
       end
 
       it "should find elements two deep" do
         #TODO reimplement so that method_missing with name is only called once.  Create a new method for name.
-        @article.name.name_content.val.should == ["Describes a person"]
-        @article.name.name_content.should == ["Describes a person"]
-        @article.name.name_content(0).should == ["Describes a person"]
+        expect(@article.name.name_content.val).to eq ["Describes a person"]
+        expect(@article.name.name_content).to eq     ["Describes a person"]
+        expect(@article.name.name_content(0)).to eq  ["Describes a person"]
       end
 
       it "should not find elements that don't  exist" do
-        lambda {@article.name.hedgehog}.should raise_exception NoMethodError
+        expect(lambda {@article.name.hedgehog}).to raise_exception NoMethodError
       end
 
       it "should allow you to call methods on the return value" do
-        @article.name.name_content.first.should == "Describes a person"
+        expect(@article.name.name_content.first).to eq "Describes a person"
       end
 
       it "Should work with proxies" do
         @article.title.should == ["ARTICLE TITLE HYDRANGEA ARTICLE 1", "Artikkelin otsikko Hydrangea artiklan 1", "TITLE OF HOST JOURNAL"]
-        @article.title.main_title_lang.should == ['eng']
+        expect(@article.title.main_title_lang).to eq ['eng']
 
-        @article.title(1).to_pointer.should == [{:title => 1}]
+        expect(@article.title(1).to_pointer).to eq [{:title => 1}]
 
-        @article.journal_title.xpath.should == "//oxns:relatedItem[@type=\"host\"]/oxns:titleInfo/oxns:title"
-        @article.journal_title.should == ["TITLE OF HOST JOURNAL"]
+        expect(@article.journal_title.xpath).to eq "//oxns:relatedItem[@type=\"host\"]/oxns:titleInfo/oxns:title"
+        expect(@article.journal_title).to eq ["TITLE OF HOST JOURNAL"]
       end
 
       it "Should be addressable to a specific node" do
         @article.update_values( {[{:journal=>0}, {:issue=>3}, :pages, :start]=>"434"})
 
         @article.subject.topic(1).to_pointer == [:subject, {:topic => 1}]
-        @article.journal(0).issue.length.should == 2
-        @article.journal(0).issue(1).pages.to_pointer == [{:journal=>0}, {:issue=>1}, :pages]
-        @article.journal(0).issue(1).pages.length.should == 1
-        @article.journal(0).issue(1).pages.start.length.should == 1
-        @article.journal(0).issue(1).pages.start.first.should == "434"
+        expect(@article.journal(0).issue.length).to eq 2
+        expect(@article.journal(0).issue(1).pages.to_pointer).to eq [{:journal=>0}, {:issue=>1}, :pages]
+        expect(@article.journal(0).issue(1).pages.length).to eq 1
+        expect(@article.journal(0).issue(1).pages.start.length).to eq 1
+        expect(@article.journal(0).issue(1).pages.start.first).to eq "434"
 
-        @article.subject.topic(1).should == ["TOPIC 2"]
-        @article.subject.topic(1).xpath.should == "//oxns:subject/oxns:topic[2]"
+        expect(@article.subject.topic(1)).to eq ["TOPIC 2"]
+        expect(@article.subject.topic(1).xpath).to eq "//oxns:subject/oxns:topic[2]"
       end
       
       describe ".nodeset" do
@@ -153,35 +153,35 @@ describe "OM::XML::DynamicNode" do
           @article.update_values( {[{:journal=>0}, {:issue=>3}, :pages, :start]=>"434" })
           nodeset = @article.journal(0).issue(1).pages.start.nodeset
           nodeset.should be_kind_of Nokogiri::XML::NodeSet
-          nodeset.length.should == @article.journal(0).issue(1).pages.start.length
-          nodeset.first.text.should == @article.journal(0).issue(1).pages.start.first
+          expect(nodeset.length).to eq @article.journal(0).issue(1).pages.start.length
+          expect(nodeset.first.text).to eq @article.journal(0).issue(1).pages.start.first
         end
       end
 
       it "should append nodes at the specified index if possible" do
         @article.journal.title_info = ["all", "for", "the"]
         @article.journal.title_info(3, 'glory')
-        @article.term_values(:journal, :title_info).should == ["all", "for", "the", "glory"]
-        @article.should be_changed
+        expect(@article.term_values(:journal, :title_info)).to eq ["all", "for", "the", "glory"]
+        expect(@article).to be_changed
       end
     
       it "should remove extra nodes if fewer are given than currently exist" do
         @article.journal.title_info = %W(one two three four five)
         @article.journal.title_info = %W(six seven)
-        @article.journal.title_info.should == ["six", "seven"]
+        expect(@article.journal.title_info).to eq ["six", "seven"]
       end
 
       describe '==' do
         it "returns true when values of dynamic nodes are equal." do
           @article.name(0).last_name = "Steven"
           @article.name(0).first_name = "Steven"
-          (@article.name(0).last_name == @article.name(0).first_name).should == true
+          expect(@article.name(0).last_name).to eq @article.name(0).first_name
         end
 
         it 'returns false when values of dynamic nodes are not equal.' do
           @article.name(0).first_name = "Horatio"
           @article.name(0).last_name = "Hogginobble"
-          (@article.name(0).last_name == @article.name(0).first_name).should == false
+          expect(@article.name(0).last_name == @article.name(0).first_name).to be false
         end
       end 
     end

--- a/spec/unit/named_term_proxy_spec.rb
+++ b/spec/unit/named_term_proxy_spec.rb
@@ -35,21 +35,26 @@ describe "OM::XML::NamedTermProxy" do
       @test_proxy.send(method)
     end
   end
+
   it "should proxy the term specified by the builder" do
     @test_proxy.proxied_term.should == @test_terminology.retrieve_term(:parent, :foo, :bar)
-    @test_proxy.xpath.should == "//oxns:parent/oxns:foo/oxns:bar"
+    expect(@test_proxy.xpath).to eq "//oxns:parent/oxns:foo/oxns:bar"
   end
+
   it "should search relative to the parent term when finding the term to proxy" do
     proxy2 = @test_terminology.retrieve_term(:adoptive_parent, :my_proxy)    
-    proxy2.proxied_term.should == @test_terminology.retrieve_term(:adoptive_parent, :foo, :bar)
-    proxy2.xpath.should == '//oxns:parent[@type="adoptive"]/oxns:foo/oxns:bar'
+    expect(proxy2.proxied_term).to eq @test_terminology.retrieve_term(:adoptive_parent, :foo, :bar)
+    expect(proxy2.xpath).to eq '//oxns:parent[@type="adoptive"]/oxns:foo/oxns:bar'
   end
+
   it "should support NamedTermProxies that point to root terms" do
     @test_terminology.xpath_for(:parentfoobarproxy).should == "//oxns:parent/oxns:foo/oxns:bar"
   end
+
   it "should be usable in update_values" do
     document = NamedProxyTestDocument.from_xml(NamedProxyTestDocument.xml_template)
     document.update_values([:parentfoobarproxy] => "FOObar!")
-    document.term_values(:parentfoobarproxy).should == ["FOObar!"]
+    expect(document.term_values(:parentfoobarproxy)).to eq ["FOObar!"]
   end
+  
 end

--- a/spec/unit/node_generator_spec.rb
+++ b/spec/unit/node_generator_spec.rb
@@ -10,17 +10,17 @@ describe "OM::XML::NodeGenerator" do
   
   describe '#generate' do
     it "should use the corresponding builder template(s) to generate the node" do
-      OM::XML::NodeGenerator.generate(@test_mods_term, "foo").root.to_xml.should == "<mods>foo</mods>"
+      expect(OM::XML::NodeGenerator.generate(@test_mods_term, "foo").root.to_xml).to eq "<mods>foo</mods>"
       generated_node = OM::XML::NodeGenerator.generate(@test_volume_term, "108", {:attributes=>{"extraAttr"=>"my value"}})
-      generated_node.xpath('./detail[@type="volume"][@extraAttr="my value"]').xpath("./number").text.should == "108"
+      expect(generated_node.xpath('./detail[@type="volume"][@extraAttr="my value"]').xpath("./number").text).to eq "108"
       # Would be great if we wrote a have_node custom rspec matcher...
       # generated_node.should have_node 'role[@authority="marcrelator"][@type="code"]' do
       #   with_node "roleTerm", "creator"
       # end
     end
+
     it "should return Nokogiri Documents" do
-      OM::XML::NodeGenerator.generate(@test_mods_term, "foo").class.should == Nokogiri::XML::Document
+      expect(OM::XML::NodeGenerator.generate(@test_mods_term, "foo").class).to eq Nokogiri::XML::Document
     end
   end
-  
 end

--- a/spec/unit/nokogiri_sanity_spec.rb
+++ b/spec/unit/nokogiri_sanity_spec.rb
@@ -8,7 +8,7 @@ describe "OM::XML::TermValueOperators" do
     end
   
     it "should do" do
-      @article.find_by_terms({:journal=>0}).length.should == 1
+      expect(@article.find_by_terms({:journal=>0}).length).to eq 1
     end
   end
   
@@ -20,56 +20,55 @@ describe "OM::XML::TermValueOperators" do
     it "should respond with a hash of updated values and their indexes" do
       test_args = {[{"person"=>"0"},"description"]=>["mork", "york"]}      
       result = @article.update_values(test_args)
-      result.should == {"person_0_description"=>["mork", "york"]}
+      expect(result).to eq({"person_0_description"=>["mork", "york"]})
     end
     
     it "should update the xml in the specified datastream and know that changes have been made" do
-      @article.term_values({:person=>0}, :first_name).should == ["GIVEN NAMES"]
+      expect(@article.term_values({:person=>0}, :first_name)).to eq ["GIVEN NAMES"]
       test_args = {[{:person=>0}, :first_name]=>"Replacement FirstName"}
       @article.update_values(test_args)
-      @article.term_values({:person=>0}, :first_name).should == ["Replacement FirstName"]
-      @article.should be_changed
+      expect(@article.term_values({:person=>0}, :first_name)).to eq ["Replacement FirstName"]
+      expect(@article).to be_changed
     end
     
     it "should update the xml according to the find_by_terms_and_values in the given hash" do
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>["affiliation1", "affiliation2", "affiliation3"]}
       result = @article.update_values(terms_attributes)
-      result.should == {"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]}
+      expect(result).to eq({"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]})
       
       # Trying again with a more complex update hash
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>["affiliation1", "affiliation2", "affiliation3"], [{:person=>1}, :last_name]=>"Andronicus", [{"person"=>"1"},:first_name]=>["Titus"],[{:person=>1},:role]=>["otherrole1","otherrole2"] }
       result = @article.update_values(terms_attributes)
-      result.should == {"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"], "person_1_last_name"=>["Andronicus"],"person_1_first_name"=>["Titus"], "person_1_role"=>["otherrole1","otherrole2"]}
-      @article.should be_changed
+      expect(result).to eq({"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"], "person_1_last_name"=>["Andronicus"],"person_1_first_name"=>["Titus"], "person_1_role"=>["otherrole1","otherrole2"]})
+      expect(@article).to be_changed
     end
     
     it "should work when you re-run the command" do
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>["affiliation1", "affiliation2", "affiliation3"]}
       result = @article.update_values(terms_attributes)
-      @article.term_values( {":person"=>"0"}, "affiliation" ).should == ["affiliation1", "affiliation2", "affiliation3"]
-      result.should == {"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]}
+
+      expect(@article.term_values( {":person"=>"0"}, "affiliation" )).to eq ["affiliation1", "affiliation2", "affiliation3"]
+      expect(result).to eq({"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]})
       
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>["affiliation1", "affiliation2", "affiliation3"]}
       @article = OM::Samples::ModsArticle.from_xml( fixture( File.join("mods_articles","hydrangea_article1.xml") ) )
       result = @article.update_values(terms_attributes)
-      @article.term_values( {":person"=>"0"}, "affiliation" ).should == ["affiliation1", "affiliation2", "affiliation3"]
-      result.should == {"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]}
+      expect(@article.term_values( {":person"=>"0"}, "affiliation" )).to eq ["affiliation1", "affiliation2", "affiliation3"]
+      expect(result).to eq({"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]})
       result = @article.update_values(terms_attributes)
       
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>["affiliation1", "affiliation2", "affiliation3"]}
       @article = OM::Samples::ModsArticle.from_xml( fixture( File.join("mods_articles","hydrangea_article1.xml") ) )
       result = @article.update_values(terms_attributes)
-      @article.term_values( {":person"=>"0"}, "affiliation" ).should == ["affiliation1", "affiliation2", "affiliation3"]
-      result.should == {"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]}
+      expect(@article.term_values( {":person"=>"0"}, "affiliation" )).to eq ["affiliation1", "affiliation2", "affiliation3"]
+      expect(result).to eq({"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"]})
       
       # Trying again with a more complex update hash
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>["affiliation1", "affiliation2", "affiliation3"], [{:person=>1}, :last_name]=>"Andronicus", [{"person"=>"1"},:first_name]=>["Titus"],[{:person=>1},:role]=>["otherrole1","otherrole2"] }
       result = @article.update_values(terms_attributes)
-      result.should == {"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"], "person_1_last_name"=>["Andronicus"],"person_1_first_name"=>["Titus"], "person_1_role"=>["otherrole1", "otherrole2"]}
-      @article.should be_changed
+      expect(result).to eq({"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"], "person_1_last_name"=>["Andronicus"],"person_1_first_name"=>["Titus"], "person_1_role"=>["otherrole1", "otherrole2"]})
+      expect(@article).to be_changed
     end
   end
-  
 
-  
 end

--- a/spec/unit/om_spec.rb
+++ b/spec/unit/om_spec.rb
@@ -4,8 +4,8 @@ describe "OM" do
   
   describe "#{}destringify" do
     it "should recursively change any strings beginning with : to symbols and any number strings to integers" do
-      OM.destringify( [{":person"=>"0"}, ":last_name"] ).should == [{:person=>0}, :last_name]
-      OM.destringify( [{"person"=>"3"}, "last_name"] ).should == [{:person=>3}, :last_name]
+      expect(OM.destringify( [{":person"=>"0"}, ":last_name"] )).to eq([{:person=>0}, :last_name])
+      expect(OM.destringify( [{"person"=>"3"}, "last_name"] )).to eq([{:person=>3}, :last_name])
     end
   end
   

--- a/spec/unit/template_registry_spec.rb
+++ b/spec/unit/template_registry_spec.rb
@@ -38,8 +38,8 @@ describe "OM::XML::TemplateRegistry" do
   
   describe "template definitions" do
     it "should contain predefined templates" do
-      RegistryTest.template_registry.node_types.should include(:person)
-      RegistryTest.template_registry.node_types.should_not include(:zombie)
+      expect(RegistryTest.template_registry.node_types).to include(:person)
+      expect(RegistryTest.template_registry.node_types).not_to include(:zombie)
     end
 
     it "should define new templates" do
@@ -73,85 +73,85 @@ describe "OM::XML::TemplateRegistry" do
     end
     
     it "should complain if the template name isn't a symbol" do
-      lambda { RegistryTest.template_registry.define("die!") { |xml| xml.this_never_happened } }.should raise_error(TypeError)
+      expect(lambda { RegistryTest.template_registry.define("die!") { |xml| xml.this_never_happened } }).to raise_error(TypeError)
     end
     
     it "should report on whether a given template is defined" do
-      RegistryTest.template_registry.has_node_type?(:person).should == true
-      RegistryTest.template_registry.has_node_type?(:zombie).should == false
+      expect(RegistryTest.template_registry.has_node_type?(:person)).to eq true
+      expect(RegistryTest.template_registry.has_node_type?(:zombie)).to eq false
     end
     
     it "should include defined node_types as method names for introspection" do
-      RegistryTest.template_registry.methods.should include('person')
+      expect(RegistryTest.template_registry.methods).to include('person')
     end
   end
   
   describe "template-based document manipulations" do
     it "should accept a Nokogiri::XML::Node as target" do
       @test_document.template_registry.after(@test_document.ng_xml.root.elements.first, :person, 'Bob', 'Builder')
-      @test_document.ng_xml.root.elements.length.should == 2
+      expect(@test_document.ng_xml.root.elements.length).to eq 2
     end
 
     it "should accept a Nokogiri::XML::NodeSet as target" do
       @test_document.template_registry.after(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
-      @test_document.ng_xml.root.elements.length.should == 2
+      expect(@test_document.ng_xml.root.elements.length).to eq 2
     end
     
     it "should instantiate a detached node from a template using the template name as a method" do
       node = RegistryTest.template_registry.person('Odin', 'All-Father')
       expectation = Nokogiri::XML('<person title="All-Father">Odin</person>').root
-      node.should be_equivalent_to(expectation)
+      expect(node).to be_equivalent_to(expectation)
     end
     
     it "should add_child" do
       return_value = @test_document.template_registry.add_child(@test_document.ng_xml.root, :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 1).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:after]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 1).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:after]).respecting_element_order
     end
     
     it "should add_next_sibling" do
       return_value = @test_document.template_registry.add_next_sibling(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 1).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:after]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 1).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:after]).respecting_element_order
     end
 
     it "should add_previous_sibling" do
       return_value = @test_document.template_registry.add_previous_sibling(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
       return_value.should == @test_document.find_by_terms(:person => 0).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:before]).respecting_element_order
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:before]).respecting_element_order
     end
 
     it "should after" do
       return_value = @test_document.template_registry.after(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
       return_value.should == @test_document.find_by_terms(:person => 0).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:after]).respecting_element_order
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:after]).respecting_element_order
     end
 
     it "should before" do
       return_value = @test_document.template_registry.before(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
       return_value.should == @test_document.find_by_terms(:person => 1).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:before]).respecting_element_order
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:before]).respecting_element_order
     end
 
     it "should replace" do
       target_node = @test_document.find_by_terms(:person => 0).first
       return_value = @test_document.template_registry.replace(target_node, :person, 'Bob', 'Builder')
       return_value.should == @test_document.find_by_terms(:person => 0).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:instead]).respecting_element_order
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:instead]).respecting_element_order
     end
 
     it "should swap" do
       target_node = @test_document.find_by_terms(:person => 0).first
       return_value = @test_document.template_registry.swap(target_node, :person, 'Bob', 'Builder')
-      return_value.should == target_node
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:instead]).respecting_element_order
+      expect(return_value).to eq target_node
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:instead]).respecting_element_order
     end
     
     it "should yield the result if a block is given" do
       target_node = @test_document.find_by_terms(:person => 0).first
       expectation = Nokogiri::XML('<person xmlns="urn:registry-test" title="Actor">Alice</person>').root
       @test_document.template_registry.swap(target_node, :person, 'Bob', 'Builder') { |old_node|
-        old_node.should be_equivalent_to(expectation)
+        expect(old_node).to be_equivalent_to(expectation)
         old_node
       }.should be_equivalent_to(expectation)
     end
@@ -160,67 +160,67 @@ describe "OM::XML::TemplateRegistry" do
   describe "document-based document manipulations" do
     it "should accept a Nokogiri::XML::Node as target" do
       @test_document.after_node(@test_document.ng_xml.root.elements.first, :person, 'Bob', 'Builder')
-      @test_document.ng_xml.root.elements.length.should == 2
+      expect(@test_document.ng_xml.root.elements.length).to eq 2
     end
 
     it "should accept a Nokogiri::XML::NodeSet as target" do
       @test_document.after_node(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
-      @test_document.ng_xml.root.elements.length.should == 2
+      expect(@test_document.ng_xml.root.elements.length).to eq 2
     end
     
     it "should accept a term-pointer array as target" do
       @test_document.after_node([:person => 0], :person, 'Bob', 'Builder')
-      @test_document.ng_xml.root.elements.length.should == 2
+      expect(@test_document.ng_xml.root.elements.length).to eq 2
     end
     
     it "should instantiate a detached node from a template" do
       node = @test_document.template(:person, 'Odin', 'All-Father')
       expectation = Nokogiri::XML('<person title="All-Father">Odin</person>').root
-      node.should be_equivalent_to(expectation)
+      expect(node).to be_equivalent_to(expectation)
     end
 
     it "should add_child_node" do
       return_value = @test_document.add_child_node(@test_document.ng_xml.root, :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 1).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:after]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 1).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:after]).respecting_element_order
     end
     
     it "should add_next_sibling_node" do
       return_value = @test_document.add_next_sibling_node([:person => 0], :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 1).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:after]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 1).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:after]).respecting_element_order
     end
 
     it "should add_previous_sibling_node" do
       return_value = @test_document.add_previous_sibling_node([:person => 0], :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 0).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:before]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 0).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:before]).respecting_element_order
     end
 
     it "should after_node" do
       return_value = @test_document.after_node([:person => 0], :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 0).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:after]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 0).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:after]).respecting_element_order
     end
 
     it "should before_node" do
       return_value = @test_document.before_node([:person => 0], :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 1).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:before]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 1).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:before]).respecting_element_order
     end
 
     it "should replace_node" do
       target_node = @test_document.find_by_terms(:person => 0).first
       return_value = @test_document.replace_node(target_node, :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 0).first
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:instead]).respecting_element_order
+      expect(return_value).to eq @test_document.find_by_terms(:person => 0).first
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:instead]).respecting_element_order
     end
 
     it "should swap_node" do
       target_node = @test_document.find_by_terms(:person => 0).first
       return_value = @test_document.swap_node(target_node, :person, 'Bob', 'Builder')
-      return_value.should == target_node
-      @test_document.ng_xml.should be_equivalent_to(@expectations[:instead]).respecting_element_order
+      expect(return_value).to eq target_node
+      expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:instead]).respecting_element_order
     end
   end
   

--- a/spec/unit/term_builder_spec.rb
+++ b/spec/unit/term_builder_spec.rb
@@ -34,7 +34,7 @@ describe "OM::XML::Term::Builder" do
   describe '#new' do
    it "should set terminology_builder attribute if provided" do
      mock_terminology_builder = double("TerminologyBuilder")
-     OM::XML::Term::Builder.new("term1", mock_terminology_builder).terminology_builder.should == mock_terminology_builder
+     expect(OM::XML::Term::Builder.new("term1", mock_terminology_builder).terminology_builder).to eq mock_terminology_builder
    end
   end
   
@@ -42,7 +42,7 @@ describe "OM::XML::Term::Builder" do
     it "should set the corresponding .settings value return the mapping object" do
       [:path, :index_as, :required, :type, :variant_of, :path, :attributes, :default_content_path].each do |method_name|
         @test_builder.send("#{method_name}=".to_sym, "#{method_name.to_s}foo")
-        @test_builder.settings[method_name].should == "#{method_name.to_s}foo"
+        expect(@test_builder.settings[method_name]).to eq "#{method_name.to_s}foo"
       end
     end
     # it "should be chainable" do
@@ -59,11 +59,11 @@ describe "OM::XML::Term::Builder" do
   describe "settings" do
     describe "defaults" do
       it "should be set" do
-        @test_builder.settings[:required].should == false
-        @test_builder.settings[:type].should == :string
-        @test_builder.settings[:variant_of].should be_nil
-        @test_builder.settings[:attributes].should be_nil
-        @test_builder.settings[:default_content_path].should be_nil
+        expect(@test_builder.settings[:required]).to eq false
+        expect(@test_builder.settings[:type]).to eq :string
+        expect(@test_builder.settings[:variant_of]).to be_nil
+        expect(@test_builder.settings[:attributes]).to be_nil
+        expect(@test_builder.settings[:default_content_path]).to be_nil
       end
     end
   end
@@ -71,19 +71,19 @@ describe "OM::XML::Term::Builder" do
   describe ".add_child" do
     it "should insert the given Term Builder into the current Term Builder's children" do
       @test_builder.add_child(@test_builder_2)
-      @test_builder.children[@test_builder_2.name].should == @test_builder_2
+      expect(@test_builder.children[@test_builder_2.name]).to eq @test_builder_2
     end
   end
   describe ".retrieve_child" do
     it "should fetch the child identified by the given name" do
       @test_builder.add_child(@test_builder_2)
-      @test_builder.retrieve_child(@test_builder_2.name).should == @test_builder.children[@test_builder_2.name]
+      expect(@test_builder.retrieve_child(@test_builder_2.name)).to eq @test_builder.children[@test_builder_2.name]
     end
   end
   describe ".children" do
     it "should return a hash of Term Builders that are the children of the current object, indexed by name" do
       @test_builder.add_child(@test_builder_2)
-      @test_builder.children[@test_builder_2.name].should == @test_builder_2
+      expect(@test_builder.children[@test_builder_2.name]).to eq @test_builder_2
     end
   end
   
@@ -95,14 +95,14 @@ describe "OM::XML::Term::Builder" do
         t.type = :text
       end
       result = test_builder.build
-      result.should be_instance_of OM::XML::Term
-      result.index_as.should == [:facetable, :searchable, :sortable, :displayable]
-      result.required.should == true 
-      result.type.should == :text
+      expect(result).to be_instance_of OM::XML::Term
+      expect(result.index_as).to eq [:facetable, :searchable, :sortable, :displayable]
+      expect(result.required).to eq true 
+      expect(result.type).to eq :text
       
-      result.xpath.should == OM::XML::TermXpathGenerator.generate_absolute_xpath(result)
-      result.xpath_constrained.should == OM::XML::TermXpathGenerator.generate_constrained_xpath(result)
-      result.xpath_relative.should == OM::XML::TermXpathGenerator.generate_relative_xpath(result)
+      expect(result.xpath).to eq   OM::XML::TermXpathGenerator.generate_absolute_xpath(result)
+      expect(result.xpath_constrained).to eq   OM::XML::TermXpathGenerator.generate_constrained_xpath(result)
+      expect(result.xpath_relative).to eq  OM::XML::TermXpathGenerator.generate_relative_xpath(result)
     end
     it "should create proxy terms if :proxy is set" do
       test_builder = OM::XML::Term::Builder.new("my_proxy").tap do |t|
@@ -112,8 +112,8 @@ describe "OM::XML::Term::Builder" do
       result.should be_kind_of OM::XML::NamedTermProxy
     end
     it "should set path to match name if it is empty" do
-      @test_builder.settings[:path].should be_nil
-      @test_builder.build.path.should == @test_builder.name.to_s
+      expect(@test_builder.settings[:path]).to be_nil
+      expect(@test_builder.build.path).to eq @test_builder.name.to_s
     end
     it "should work recursively, calling .build on any of its children" do
       OM::XML::Term.any_instance.stub(:generate_xpath_queries!)
@@ -127,30 +127,31 @@ describe "OM::XML::Term::Builder" do
 
       @test_builder.children = {:mock1=>mock1, :mock2=>mock2}
       result = @test_builder.build
-      result.children[:child1].should == built_child1
-      result.children[:child2].should == built_child2
-      result.children.length.should == 2
+      expect(result.children[:child1]).to eq built_child1
+      expect(result.children[:child2]).to eq built_child2
+      expect(result.children.length).to eq 2
     end
   end
   
   describe ".lookup_refs" do
     it "should return an empty array if no refs are declared" do
-      @test_builder.lookup_refs.should == []
+      expect(@test_builder.lookup_refs).to eq []
     end
     it "should should look up the referenced TermBuilder from the terminology_builder" do
-       @peach.lookup_refs.should == [@stone_fruit]
+       expect(@peach.lookup_refs).to eq [@stone_fruit]
     end
     it "should support recursive refs" do
-	    @almond.lookup_refs.should == [@peach, @stone_fruit]
+	    expect(@almond.lookup_refs).to eq [@peach, @stone_fruit]
 	  end
   	it "should raise an error if the TermBuilder does not have a reference to a terminology builder" do
-  	  lambda { 
+  	  expect(lambda { 
         OM::XML::Term::Builder.new("referrer").tap do |t|
           t.ref="bongos"
           t.lookup_refs 
         end
-      }.should raise_error(StandardError,"Cannot perform lookup_ref for the referrer builder.  It doesn't have a reference to any terminology builder")
+      }).to raise_error(StandardError,"Cannot perform lookup_ref for the referrer builder.  It doesn't have a reference to any terminology builder")
 	  end
+
     it "should raise an error if the referece points to a nonexistent term builder" do
       tb = OM::XML::Term::Builder.new("mork",@test_terminology_builder).tap do |t|
         t.ref = [:characters, :aliens]
@@ -168,8 +169,8 @@ describe "OM::XML::Term::Builder" do
       children_pre = @test_builder.children
 
       @test_builder.resolve_refs!
-      @test_builder.settings.should == settings_pre
-      @test_builder.children.should == children_pre
+      expect(@test_builder.settings).to eq settings_pre
+      expect(@test_builder.children).to eq children_pre
     end
     it "should should look up the referenced TermBuilder, use its settings and duplicate its children without changing the name" do
       term_builder = OM::XML::Term::Builder.new("orange",@test_terminology_builder).tap do |b|
@@ -177,24 +178,24 @@ describe "OM::XML::Term::Builder" do
       end
       term_builder.resolve_refs!
       # Make sure children and settings were copied
-      term_builder.settings.should == @citrus.settings.merge(:path=>"citrus")
-  	  term_builder.children.should == @citrus.children
+      expect(term_builder.settings).to eq @citrus.settings.merge(:path=>"citrus")
+  	  expect(term_builder.children).to eq @citrus.children
   	  
   	  # Make sure name and parent of both the term_builder and its target were left alone
-  	  term_builder.name.should == :orange
-  	  @citrus.name.should == :citrus
+  	  expect(term_builder.name).to eq :orange
+  	  expect(@citrus.name).to eq :citrus
     end
     it "should set path based on the ref's path if set" do
       [@peach,@almond].each { |x| x.resolve_refs! }
-      @peach.settings[:path].should == "prunus"
-      @almond.settings[:path].should == "prunus"
+      expect(@peach.settings[:path]).to eq "prunus"
+      expect(@almond.settings[:path]).to eq "prunus"
     end
     it "should set path based on the first ref's name if no path is set" do
       orange_builder = OM::XML::Term::Builder.new("orange",@test_terminology_builder).tap do |b|
         b.ref= [:fruit_trees, :citrus]
       end
       orange_builder.resolve_refs!
-      orange_builder.settings[:path].should == "citrus"
+      expect(orange_builder.settings[:path]).to eq "citrus"
     end
     # It should not be a problem if multiple TermBuilders refer to the same child TermBuilder since the parent-child relationship is set up after calling TermBuilder.build 
     it "should result in clean trees of Terms after building" 
@@ -206,11 +207,11 @@ describe "OM::XML::Term::Builder" do
         b.required =true
       end
   	  tb.resolve_refs!
-  	  tb.settings.should == {:path=>"citrus", :attributes=>{"citric_acid"=>"true", :color=>"orange"}, :required=>true, :type=>:string, :index_as=>[:facetable]}
+  	  expect(tb.settings).to eq({:path=>"citrus", :attributes=>{"citric_acid"=>"true", :color=>"orange"}, :required=>true, :type=>:string, :index_as=>[:facetable]})
 	  end
 	  it "should aggregate all settings from refs, combining them with a cascading approach" do
 	    @almond.resolve_refs!
-	    @almond.settings[:attributes].should == {:genus=>"Prunus",:subgenus=>"Amygdalus", :species=>"Prunus dulcis"}
+	    expect(@almond.settings[:attributes]).to eq({:genus=>"Prunus",:subgenus=>"Amygdalus", :species=>"Prunus dulcis"})
     end
   end
 end

--- a/spec/unit/term_spec.rb
+++ b/spec/unit/term_spec.rb
@@ -8,7 +8,7 @@ describe OM::XML::Term do
   end
   describe "when type is specified" do
     it "should accept date" do
-      OM::XML::Term.new(:test_term, :type=>:date).type.should == :date
+      expect(OM::XML::Term.new(:test_term, :type=>:date).type).to eq :date
     end
   end
 
@@ -25,20 +25,20 @@ describe OM::XML::Term do
 
     describe '#new' do
       it "should set path from mapper name if no path is provided" do
-        @test_name_part.path.should == "namePart"
+        expect(@test_name_part.path).to eq "namePart"
       end
       it "should populate the xpath values if no options are provided" do
         local_mapping = OM::XML::Term.new(:namePart)
-        local_mapping.xpath_relative.should be_nil
-        local_mapping.xpath.should be_nil
-        local_mapping.xpath_constrained.should be_nil
+        expect(local_mapping.xpath_relative).to be_nil
+        expect(local_mapping.xpath).to be_nil
+        expect(local_mapping.xpath_constrained).to be_nil
       end
     end
 
     describe 'inner_xml' do
       it "should be a kind of Nokogiri::XML::Node" do
         skip
-        @test_mapping.inner_xml.should be_kind_of(Nokogiri::XML::Node)
+        expect(@test_mapping.inner_xml).to be_kind_of(Nokogiri::XML::Node)
       end
     end
 
@@ -57,17 +57,17 @@ describe OM::XML::Term do
         # node = Nokogiri::XML::Document.parse( '<mapper name="first_name" path="namePart"><attribute name="type" value="given"/><attribute name="another_attribute" value="myval"/></mapper>' ).root
         node = ng_builder.doc.root
         mapper = OM::XML::Term.from_node(node)
-        mapper.name.should == :person
-        mapper.path.should == "name"
-        mapper.attributes.should == {:type=>"personal"}
-        mapper.internal_xml.should == node
+        expect(mapper.name).to eq :person
+        expect(mapper.path).to eq "name"
+        expect(mapper.attributes).to eq({:type=>"personal"})
+        expect(mapper.internal_xml).to eq node
 
         child = mapper.children[:first_name]
 
-        child.name.should == :first_name
-        child.path.should == "namePart"
-        child.attributes.should == {:type=>"given", :another_attribute=>"myval"}
-        child.internal_xml.should == node.xpath("./mapper").first
+        expect(child.name).to eq :first_name
+        expect(child.path).to eq "namePart"
+        expect(child.attributes).to eq({:type=>"given", :another_attribute=>"myval"})
+        expect(child.internal_xml).to eq node.xpath("./mapper").first
       end
     end
 
@@ -80,17 +80,17 @@ describe OM::XML::Term do
         mock_role = double("mapper", :children =>{:text=>"the target"})
         mock_conference = double("mapper", :children =>{:role=>mock_role})
         @test_name_part.should_receive(:children).and_return({:conference=>mock_conference})
-        @test_name_part.retrieve_term(:conference, :role, :text).should == "the target"
+        expect(@test_name_part.retrieve_term(:conference, :role, :text)).to eq "the target"
       end
       it "should return an empty hash if no term can be found" do
-        @test_name_part.retrieve_term(:journal, :issue, :end_page).should == nil
+        expect(@test_name_part.retrieve_term(:journal, :issue, :end_page)).to be_nil
       end
     end
 
     describe 'inner_xml' do
       it "should be a kind of Nokogiri::XML::Node" do
         skip
-        @test_name_part.inner_xml.should be_kind_of(Nokogiri::XML::Node)
+        expect(@test_name_part.inner_xml).to be_kind_of(Nokogiri::XML::Node)
       end
     end
 
@@ -100,7 +100,7 @@ describe OM::XML::Term do
 
         [:path, :required, :type, :variant_of, :path, :attributes, :default_content_path, :namespace_prefix].each do |method_name|
           @test_name_part.send((method_name.to_s+"=").to_sym, "#{method_name.to_s}foo")
-          @test_name_part.send(method_name).should == "#{method_name.to_s}foo"
+          expect(@test_name_part.send(method_name)).to eq "#{method_name.to_s}foo"
         end
       end
     end
@@ -120,71 +120,71 @@ describe OM::XML::Term do
       }
 
       it "should accept an array as an :index_as value" do
-        subject.terminology.terms[:as_array].index_as.should be_a_kind_of(Array)
-        subject.terminology.terms[:as_array].index_as.should == [:not_searchable]
+        expect(subject.terminology.terms[:as_array].index_as).to be_a_kind_of(Array)
+        expect(subject.terminology.terms[:as_array].index_as).to eq [:not_searchable]
       end
       it "should accept a plain symbol as a value to :index_as" do
-        subject.terminology.terms[:as_symbol].index_as.should be_a_kind_of(Array)
-        subject.terminology.terms[:as_symbol].index_as.should == [:not_searchable]
+        expect(subject.terminology.terms[:as_symbol].index_as).to be_a_kind_of(Array)
+        expect(subject.terminology.terms[:as_symbol].index_as).to eq [:not_searchable]
       end
     end
     it "should have a .terminology attribute accessor" do
-      @test_volume.should respond_to :terminology
-      @test_volume.should respond_to :terminology=
+      expect(@test_volume).to respond_to :terminology
+      expect(@test_volume).to respond_to :terminology=
     end
     describe ".ancestors" do
       it "should return an array of Terms that are the ancestors of the current object, ordered from the top/root of the hierarchy" do
         @test_volume.set_parent(@test_name_part)
-        @test_volume.ancestors.should == [@test_name_part]
+        expect(@test_volume.ancestors).to eq [@test_name_part]
       end
     end
     describe ".parent" do
       it "should retrieve the immediate parent of the given object from the ancestors array" do
         @test_name_part.ancestors = ["ancestor1","ancestor2","ancestor3"]
-        @test_name_part.parent.should == "ancestor3"
+        expect(@test_name_part.parent).to eq "ancestor3"
       end
     end
     describe ".children" do
       it "should return a hash of Terms that are the children of the current object, indexed by name" do
         @test_volume.add_child(@test_name_part)
-        @test_volume.children[@test_name_part.name].should == @test_name_part
+        expect(@test_volume.children[@test_name_part.name]).to eq @test_name_part
       end
     end
     describe ".retrieve_child" do
       it "should fetch the child identified by the given name" do
         @test_volume.add_child(@test_name_part)
-        @test_volume.retrieve_child(@test_name_part.name).should == @test_volume.children[@test_name_part.name]
+        expect(@test_volume.retrieve_child(@test_name_part.name)).to eq @test_volume.children[@test_name_part.name]
       end
     end
     describe ".set_parent" do
       it "should insert the mapper into the given parent" do
         @test_name_part.set_parent(@test_volume)
-        @test_name_part.ancestors.should include(@test_volume)
-        @test_volume.children[@test_name_part.name].should == @test_name_part
+        expect(@test_name_part.ancestors).to include(@test_volume)
+        expect(@test_volume.children[@test_name_part.name]).to eq @test_name_part
       end
     end
     describe ".add_child" do
       it "should insert the given mapper into the current mappers children" do
         @test_volume.add_child(@test_name_part)
-        @test_volume.children[@test_name_part.name].should == @test_name_part
-        @test_name_part.ancestors.should include(@test_volume)
+        expect(@test_volume.children[@test_name_part.name]).to eq @test_name_part
+        expect(@test_name_part.ancestors).to include(@test_volume)
       end
     end
 
     describe "generate_xpath_queries!" do
       it "should return the current object" do
-        @test_name_part.generate_xpath_queries!.should == @test_name_part
+        expect(@test_name_part.generate_xpath_queries!).to eq @test_name_part
       end
       it "should regenerate the xpath values" do
-        @test_volume.xpath_relative.should be_nil
-        @test_volume.xpath.should be_nil
-        @test_volume.xpath_constrained.should be_nil
+        expect(@test_volume.xpath_relative).to be_nil
+        expect(@test_volume.xpath).to be_nil
+        expect(@test_volume.xpath_constrained).to be_nil
 
-        @test_volume.generate_xpath_queries!.should == @test_volume
+        expect(@test_volume.generate_xpath_queries!).to eq @test_volume
 
-        @test_volume.xpath_relative.should == 'detail[@type="volume"]'
-        @test_volume.xpath.should == '//detail[@type="volume"]'
-        @test_volume.xpath_constrained.should == '//detail[@type="volume" and contains(number, "#{constraint_value}")]'.gsub('"', '\"')
+        expect(@test_volume.xpath_relative).to eq 'detail[@type="volume"]'
+        expect(@test_volume.xpath).to eq '//detail[@type="volume"]'
+        expect(@test_volume.xpath_constrained).to eq '//detail[@type="volume" and contains(number, "#{constraint_value}")]'.gsub('"', '\"')
       end
       it "should trigger update on any child objects" do
         mock_child = double("child term")
@@ -197,9 +197,9 @@ describe OM::XML::Term do
     describe "#xml_builder_template" do
 
       it "should generate a template call for passing into the builder block (assumes 'xml' as the argument for the block)" do
-        @test_date.xml_builder_template.should == 'xml.namePart( \'#{builder_new_value}\', \'type\'=>\'date\' )'
-        @test_person.xml_builder_template.should == 'xml.namePart( \'#{builder_new_value}\' )'
-        @test_affiliation.xml_builder_template.should == 'xml.affiliation( \'#{builder_new_value}\' )'
+        expect(@test_date.xml_builder_template).to eq 'xml.namePart( \'#{builder_new_value}\', \'type\'=>\'date\' )'
+        expect(@test_person.xml_builder_template).to eq 'xml.namePart( \'#{builder_new_value}\' )'
+        expect(@test_affiliation.xml_builder_template).to eq 'xml.affiliation( \'#{builder_new_value}\' )'
       end
 
       it "should accept extra options" do
@@ -208,37 +208,37 @@ describe OM::XML::Term do
         e1 = %q{xml.roleTerm( '#{builder_new_value}', 'type'=>'code', 'authority'=>'marcrelator' )}
         e2 = %q{xml.roleTerm( '#{builder_new_value}', 'authority'=>'marcrelator', 'type'=>'code' )}
         got = @test_role_code.xml_builder_template(:attributes=>{"authority"=>"marcrelator"})
-        [e1, e2].should include(got)
+        expect([e1, e2]).to include(got)
       end
 
       it "should work for namespaced nodes" do
         @ical_date = OM::XML::Term.new(:ical_date, :path=>"ical:date")
-        @ical_date.xml_builder_template.should == "xml[\'ical\'].date( '\#{builder_new_value}' )"
+        expect(@ical_date.xml_builder_template).to eq "xml[\'ical\'].date( '\#{builder_new_value}' )"
         @ical_date = OM::XML::Term.new(:ical_date, :path=>"date", :namespace_prefix=>"ical")
-        @ical_date.xml_builder_template.should == "xml[\'ical\'].date( '\#{builder_new_value}' )"
+        expect(@ical_date.xml_builder_template).to eq "xml[\'ical\'].date( '\#{builder_new_value}' )"
       end
 
       it "should work for nodes with default_content_path" do
-        @test_volume.xml_builder_template.should == "xml.detail( \'type\'=>'volume' ) { xml.number( '\#{builder_new_value}' ) }"
+        expect(@test_volume.xml_builder_template).to eq "xml.detail( \'type\'=>'volume' ) { xml.number( '\#{builder_new_value}' ) }"
       end
 
       it "should support terms that are attributes" do
         @type_attribute_term = OM::XML::Term.new(:type_attribute, :path=>{:attribute=>:type})
-        @type_attribute_term.xml_builder_template.should == "xml.@type( '\#{builder_new_value}' )"
+        expect(@type_attribute_term.xml_builder_template).to eq "xml.@type( '\#{builder_new_value}' )"
       end
 
       it "should support terms with namespaced attributes" do
         @french_title = OM::XML::Term.new(:french_title, :path=>"title", :attributes=>{"xml:lang"=>"fre"})
-        @french_title.xml_builder_template.should == "xml.title( '\#{builder_new_value}', 'xml:lang'=>'fre' )"
+        expect(@french_title.xml_builder_template).to eq "xml.title( '\#{builder_new_value}', 'xml:lang'=>'fre' )"
       end
 
       it "should support terms that are namespaced attributes" do
         @xml_lang_attribute_term = OM::XML::Term.new(:xml_lang_attribute, :path=>{:attribute=>"xml:lang"})
-        @xml_lang_attribute_term.xml_builder_template.should == "xml.@xml:lang( '\#{builder_new_value}' )"
+        expect(@xml_lang_attribute_term.xml_builder_template).to eq "xml.@xml:lang( '\#{builder_new_value}' )"
       end
       
       it "should generate a template call for passing into the builder block (assumes 'xml' as the argument for the block) for terms that share a name with an existing method on the builder" do
-        @test_type.xml_builder_template.should == 'xml.class_( \'#{builder_new_value}\' )'
+        expect(@test_type.xml_builder_template).to eq 'xml.class_( \'#{builder_new_value}\' )'
       end
     end
   end

--- a/spec/unit/term_value_operators_spec.rb
+++ b/spec/unit/term_value_operators_spec.rb
@@ -13,17 +13,17 @@ describe "OM::XML::TermValueOperators" do
     it "should return build an array of values from the nodeset corresponding to the given term" do
       expected_values = ["Berners-Lee", "Jobs", "Wozniak", "Klimt"]
       result = @sample.term_values(:person, :last_name)
-      result.length.should == expected_values.length
-      expected_values.each {|v| result.should include(v)}
+      expect(result.length).to eq expected_values.length
+      expected_values.each {|v| expect(result).to include(v)}
     end
 
     it "should look at the index" do
       result = @sample.term_values(:role, {:text => 3})
-      result.should == ['visionary']
+      expect(result).to eq ['visionary']
     end
 
     it "should ignore whitespace elements for a term pointing to a text() node for an element that contains children" do
-      @article.term_values(:name, :name_content).should == ["Describes a person"]
+      expect(@article.term_values(:name, :name_content)).to eq ["Describes a person"]
     end
   
   end
@@ -33,27 +33,27 @@ describe "OM::XML::TermValueOperators" do
     it "should update the xml according to the find_by_terms_and_values in the given hash" do
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>{'1' => "affiliation1", '2'=> "affiliation2", '3' => "affiliation3"}, [{:person=>1}, :last_name]=>"Andronicus", [{"person"=>"1"},:first_name]=>["Titus"],[{:person=>1},:role]=>["otherrole1","otherrole2"] }
       result = @article.update_values(terms_attributes)
-      result.should == {"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"], "person_1_last_name"=>["Andronicus"], "person_1_first_name"=>["Titus"], "person_1_role"=>["otherrole1","otherrole2"]}
+      expect(result).to eq({"person_0_affiliation"=>["affiliation1", "affiliation2", "affiliation3"], "person_1_last_name"=>["Andronicus"], "person_1_first_name"=>["Titus"], "person_1_role"=>["otherrole1","otherrole2"]})
       person_0_affiliation = @article.find_by_terms({:person=>0}, :affiliation)
-      person_0_affiliation[0].text.should == "affiliation1"
-      person_0_affiliation[1].text.should == "affiliation2"
-      person_0_affiliation[2].text.should == "affiliation3"
+      expect(person_0_affiliation[0].text).to eq "affiliation1"
+      expect(person_0_affiliation[1].text).to eq "affiliation2"
+      expect(person_0_affiliation[2].text).to eq "affiliation3"
       
       person_1_last_names = @article.find_by_terms({:person=>1}, :last_name)
-      person_1_last_names.length.should == 1
-      person_1_last_names.first.text.should == "Andronicus"
+      expect(person_1_last_names.length).to eq 1
+      expect(person_1_last_names.first.text).to eq "Andronicus"
       
       person_1_first_names = @article.find_by_terms({:person=>1}, :first_name)
-      person_1_first_names.first.text.should == "Titus"
+      expect(person_1_first_names.first.text).to eq "Titus"
       
       person_1_roles = @article.find_by_terms({:person=>1}, :role)
-      person_1_roles[0].text.should == "otherrole1"
-      person_1_roles[1].text.should == "otherrole2"
+      expect(person_1_roles[0].text).to eq "otherrole1"
+      expect(person_1_roles[1].text).to eq "otherrole2"
     end
 
     it "should allow setting a blank string " do
       @article.update_values([:abstract]=>[''])
-      @article.term_values(:abstract).should == [""]
+      expect(@article.term_values(:abstract)).to eq [""]
     end
 
     it "should call term_value_update if the corresponding node already exists" do
@@ -78,150 +78,150 @@ describe "OM::XML::TermValueOperators" do
       pointer = [:title_info, :language]
       test_val = "language value"
       @article.update_values( {pointer=>test_val} )
-      @article.term_values(*pointer).first.should == test_val
+      expect(@article.term_values(*pointer).first).to eq test_val
     end
     
     it "should not get tripped up on root nodes" do
       @article.update_values([:title_info]=>["york", "mangle","mork"])
-      @article.term_values(*[:title_info]).should == ["york", "mangle", "mork"]
+      expect(@article.term_values(*[:title_info])).to eq ["york", "mangle", "mork"]
     end
 
     it "should destringify the field key/find_by_terms_and_value pointer" do
       expected_result = {"person_0_role"=>["the role"]}
-      @article.update_values( { [{":person"=>"0"}, "role"]=>"the role" }).should == expected_result
-      @article.update_values( { [{"person"=>"0"}, "role"]=>"the role" }).should == expected_result
-      @article.update_values( { [{:person=>0}, :role]=>"the role" }).should == expected_result
+      expect(@article.update_values( { [{":person"=>"0"}, "role"]=>"the role" })).to eq expected_result
+      expect(@article.update_values( { [{"person"=>"0"}, "role"]=>"the role" })).to eq expected_result
+      expect(@article.update_values( { [{:person=>0}, :role]=>"the role" })).to eq expected_result
     end
 
     it "should replace stuff with the same value (in this case 'one')" do
       @article.update_values( { [{:person=>0}, :role]=>["one"] })
       @article.update_values( { [{:person=>0}, :role]=>["one", "two"] })
-      @article.term_values( {:person=>0}, :role).should == ["one", "two"]
+      expect(@article.term_values( {:person=>0}, :role)).to eq ["one", "two"]
     end
     
     it "should traverse named term proxies transparently" do
-      @article.term_values( :journal, :issue, :start_page).should_not == ["108"]      
+      expect(@article.term_values( :journal, :issue, :start_page)).not_to eq ["108"]      
       @article.update_values( { ["journal", "issue", "start_page"]=>"108" } )
-      @article.term_values( :journal, :issue, :start_page).should == ["108"]      
-      @article.term_values( :journal, :issue, :pages, :start).should == ["108"]
+      expect(@article.term_values( :journal, :issue, :start_page)).to eq ["108"]      
+      expect(@article.term_values( :journal, :issue, :pages, :start)).to eq ["108"]
     end
     
     it "should create the necessary ancestor nodes when necessary" do
   	  @sample.find_by_terms(:person).length.should == 4
   	  @sample.update_values([{:person=>8}, :role, :text]=>"my role")
       person_entries = @sample.find_by_terms(:person)
-      person_entries.length.should == 5
-      person_entries[4].search("./ns3:role").first.text.should == "my role" 
+      expect(person_entries.length).to eq 5
+      expect(person_entries[4].search("./ns3:role").first.text).to eq "my role" 
 	  end
 	  
     it "should create deep trees of ancestor nodes" do
       result = @article.update_values( {[{:journal=>0}, {:issue=>3}, :pages, :start]=>"434" })
-      @article.find_by_terms({:journal=>0}, :issue).length.should == 2
-      @article.find_by_terms({:journal=>0}, {:issue=>1}, :pages).length.should == 1
-      @article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).length.should == 1
-      @article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).first.text.should == "434"
+      expect(@article.find_by_terms({:journal=>0}, :issue).length).to eq 2
+      expect(@article.find_by_terms({:journal=>0}, {:issue=>1}, :pages).length).to eq 1
+      expect(@article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).length).to eq 1
+      expect(@article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).first.text).to eq "434"
       #Last argument is a filter, we must explicitly pass no filter
-      @article.class.terminology.xpath_with_indexes(:subject, {:topic=>1}, {}).should == '//oxns:subject/oxns:topic[2]'
-      @article.find_by_terms(:subject, {:topic => 1}, {}).text.should == "TOPIC 2"
+      expect(@article.class.terminology.xpath_with_indexes(:subject, {:topic=>1}, {})).to eq '//oxns:subject/oxns:topic[2]'
+      expect(@article.find_by_terms(:subject, {:topic => 1}, {}).text).to eq "TOPIC 2"
 	  end
 	  
 	  it "should accommodate appending term values with apostrophes in them"  do
-	    @article.find_by_terms(:person, :description).should be_empty  # making sure that there's no description node -- forces a value_append
+	    expect(@article.find_by_terms(:person, :description)).to be_empty  # making sure that there's no description node -- forces a value_append
       terms_update_hash =  {[:person, :description]=>" 'phrul gyi lde mig"}
       result = @article.update_values(terms_update_hash)
-      @article.term_values(:person, :description).should include(" 'phrul gyi lde mig")
+      expect(@article.term_values(:person, :description)).to include(" 'phrul gyi lde mig")
     end
     
     it "should support inserting nodes with namespaced attributes" do
       @sample.update_values({['title_info', 'french_title']=>'Le Titre'})
-      @sample.term_values('title_info', 'french_title').should == ['Le Titre']
+      expect(@sample.term_values('title_info', 'french_title')).to eq ['Le Titre']
     end
 
     it "should support inserting attributes" do
       skip "HYDRA-415"
       @sample.update_values({['title_info', 'language']=>'Le Titre'})
-      @sample.term_values('title_info', 'french_title').should == ['Le Titre']
+      expect(@sample.term_values('title_info', 'french_title')).to eq ['Le Titre']
     end
     
     it "should support inserting namespaced attributes" do
       skip "HYDRA-415"
       @sample.update_values({['title_info', 'main_title', 'main_title_lang']=>'eng'})
-      @sample.term_values('title_info', 'main_title', 'main_title_lang').should == ['eng']
+      expect(@sample.term_values('title_info', 'main_title', 'main_title_lang')).to eq ['eng']
       ## After a proxy
-      @article.term_values(:title,:main_title_lang).should == ['eng']
+      expect(@article.term_values(:title,:main_title_lang)).to eq ['eng']
     end
     
     ### Examples copied over form nokogiri_datastream_spec
     
     it "should apply submitted hash to corresponding datastream field values" do
       result = @article.update_values( {[{":person"=>"0"}, "first_name"]=>["Billy", "Bob", "Joe"] })
-      result.should == {"person_0_first_name"=>["Billy", "Bob", "Joe"]}
+      expect(result).to eq({"person_0_first_name"=>["Billy", "Bob", "Joe"]})
       # xpath = ds.class.xpath_with_indexes(*field_key)
       # result = ds.term_values(xpath)
-      @article.term_values({:person=>0}, :first_name).should == ["Billy","Bob","Joe"]
-      @article.term_values('//oxns:name[@type="personal"][1]/oxns:namePart[@type="given"]').should == ["Billy","Bob","Joe"]
+      expect(@article.term_values({:person=>0}, :first_name)).to eq ["Billy","Bob","Joe"]
+      expect(@article.term_values('//oxns:name[@type="personal"][1]/oxns:namePart[@type="given"]')).to eq ["Billy","Bob","Joe"]
     end
     it "should support single-value arguments (as opposed to a hash of values with array indexes as keys)" do
       # In other words, { [:journal, :title_info]=>"dork" } should have the same effect as { [:journal, :title_info]=>{"0"=>"dork"} }
       result = @article.update_values( { [{":person"=>"0"}, "role"]=>"the role" } )
-      result.should == {"person_0_role"=>["the role"]}
-      @article.term_values({:person=>0}, :role).first.should == "the role"     
-      @article.term_values('//oxns:name[@type="personal"][1]/oxns:role').first.should == "the role"
+      expect(result).to eq({"person_0_role"=>["the role"]})
+      expect(@article.term_values({:person=>0}, :role).first).to eq "the role"     
+      expect(@article.term_values('//oxns:name[@type="personal"][1]/oxns:role').first).to eq "the role"
     end
     it "should do nothing if field key is a string (must be an array or symbol).  Will not accept xpath queries!" do
       xml_before = @article.to_xml
-      @article.update_values( { "fubar"=>"the role" } ).should == {}
-      @article.to_xml.should == xml_before
+      expect(@article.update_values( { "fubar"=>"the role" } )).to eq({})
+      expect(@article.to_xml).to eq xml_before
     end
     it "should do nothing if there is no term corresponding to the given field key" do
       xml_before = @article.to_xml
-      @article.update_values( { [{"fubar"=>"0"}]=>"the role" } ).should == {}
-      @article.to_xml.should == xml_before
+      expect(@article.update_values( { [{"fubar"=>"0"}]=>"the role" } )).to eq({})
+      expect(@article.to_xml).to eq xml_before
     end
     
     it "should work for text fields" do 
       att= {[{"person"=>"0"},"description"]=>["mork", "york"]}
       result = @article.update_values(att)
-      result.should == {"person_0_description"=>["mork", "york"]}
-      @article.term_values({:person=>0},:description).should == ['mork', 'york']
+      expect(result).to eq({"person_0_description"=>["mork", "york"]})
+      expect(@article.term_values({:person=>0},:description)).to eq ['mork', 'york']
       att= {[{"person"=>"0"},{"description" => 2}]=>"dork"}
       result2 = @article.update_values(att)
-      result2.should == {"person_0_description_2"=>["dork"]}
-      @article.term_values({:person=>0},:description).should == ['mork', 'york', 'dork']
+      expect(result2).to eq({"person_0_description_2"=>["dork"]})
+      expect(@article.term_values({:person=>0},:description)).to eq ['mork', 'york', 'dork']
     end
     
     it "should append nodes at the specified index if possible" do
       @article.update_values([:journal, :title_info]=>["all", "for", "the"])
       att = {[:journal, {:title_info => 3}]=>'glory'}
       result = @article.update_values(att)
-      result.should == {"journal_title_info_3"=>["glory"]}
-      @article.term_values(:journal, :title_info).should == ["all", "for", "the", "glory"]
+      expect(result).to eq({"journal_title_info_3"=>["glory"]})
+      expect(@article.term_values(:journal, :title_info)).to eq ["all", "for", "the", "glory"]
     end
 
     it "should remove extra nodes if fewer are given than currently exist" do
       @article.update_values([:journal, :title_info]=>%W(one two three four five))
       result = @article.update_values({[:journal, :title_info]=>["six", "seven"]})
-      @article.term_values(:journal, :title_info).should == ["six", "seven"]
+      expect((@article.term_values(:journal, :title_info))).to eq ["six", "seven"]
     end
     
     it "should append values to the end of the array if the specified index is higher than the length of the values array" do
       att = {[:journal, :issue, :pages, {:end => 3}]=>'108'}
-      @article.term_values(:journal, :issue, :pages, :end).should == []
+      expect(@article.term_values(:journal, :issue, :pages, :end)).to eq []
       result = @article.update_values(att)
-      result.should == {"journal_issue_pages_end_3"=>["108"]}
-      @article.term_values(:journal, :issue, :pages, :end).should == ["108"]
+      expect(result).to eq({"journal_issue_pages_end_3"=>["108"]})
+      expect(@article.term_values(:journal, :issue, :pages, :end)).to eq ["108"]
     end
     
     it "should allow deleting of values and should delete values so that to_xml does not return emtpy nodes" do
       att= {[:journal, :title_info]=>["york", "mangle","mork"]}
       @article.update_values(att)
-      @article.term_values(:journal, :title_info).should == ['york', 'mangle', 'mork']
+      expect(@article.term_values(:journal, :title_info)).to eq ['york', 'mangle', 'mork']
       
       @article.update_values({[:journal, {:title_info => 1}]=>nil})
-      @article.term_values(:journal, :title_info).should == ['york', 'mork']
+      expect(@article.term_values(:journal, :title_info)).to eq ['york', 'mork']
       
       @article.update_values({[:journal, {:title_info => 0}]=>:delete})
-      @article.term_values(:journal, :title_info).should == ['mork']
+      expect(@article.term_values(:journal, :title_info)).to eq ['mork']
     end
 
     describe "delete_on_update?" do
@@ -229,27 +229,27 @@ describe "OM::XML::TermValueOperators" do
       before(:each) do
         att= {[:journal, :title_info]=>["york", "mangle","mork"]}
         @article.update_values(att)
-        @article.term_values(:journal, :title_info).should == ['york', 'mangle', 'mork']
+        expect(@article.term_values(:journal, :title_info)).to eq ['york', 'mangle', 'mork']
       end
 
       it "by default, setting to nil deletes the node" do
         @article.update_values({[:journal, {:title_info => 1}]=>nil})
-        @article.term_values(:journal, :title_info).should == ['york', 'mork']
+        expect(@article.term_values(:journal, :title_info)).to eq ['york', 'mork']
       end
 
       it "if delete_on_update? returns false, setting to nil won't delete node" do
         @article.stub('delete_on_update?').and_return(false)
         @article.update_values({[:journal, {:title_info => 1}]=>""})
-        @article.term_values(:journal, :title_info).should == ['york', '', 'mork']
+        expect(@article.term_values(:journal, :title_info)).to eq ['york', '', 'mork']
       end
 
     end
 
     it "should retain other child nodes when updating a text content term and shoud not append an additional text node but update text in place" do
-      @article.term_values(:name,:name_content).should == ["Describes a person"]
+      expect(@article.term_values(:name,:name_content)).to eq ["Describes a person"]
       @article.update_values({[:name, :name_content]=>"Test text"})
-      @article.term_values(:name,:name_content).should == ["Test text"]
-      @article.find_by_terms(:name).children.length().should == 35
+      expect(@article.term_values(:name,:name_content)).to eq ["Test text"]
+      expect(@article.find_by_terms(:name).children.length()).to eq 35
     end
     
   end

--- a/spec/unit/term_xpath_generator_spec.rb
+++ b/spec/unit/term_xpath_generator_spec.rb
@@ -27,9 +27,9 @@ describe "OM::XML::TermXpathGeneratorSpec" do
   end
 
   it "should support terms that are pointers to attribute values" do
-    OM::XML::TermXpathGenerator.generate_xpath(@test_lang_attribute, :absolute).should == "//@lang"
-    OM::XML::TermXpathGenerator.generate_xpath(@test_lang_attribute, :relative).should == "@lang"
-    OM::XML::TermXpathGenerator.generate_xpath(@test_lang_attribute, :constrained).should == '//@lang[contains(., "#{constraint_value}")]'.gsub('"', '\"')
+    expect(OM::XML::TermXpathGenerator.generate_xpath(@test_lang_attribute, :absolute)).to eq "//@lang"
+    expect(OM::XML::TermXpathGenerator.generate_xpath(@test_lang_attribute, :relative)).to eq "@lang"
+    expect(OM::XML::TermXpathGenerator.generate_xpath(@test_lang_attribute, :constrained)).to eq '//@lang[contains(., "#{constraint_value}")]'.gsub('"', '\"')
   end
 
   describe "generate_xpath" do
@@ -47,44 +47,44 @@ describe "OM::XML::TermXpathGeneratorSpec" do
 
   describe "generate_relative_xpath" do
     it "should generate a relative xpath based on the given mapper" do
-      OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term).should == 'namePart[@type="termsOfAddress"]'
+      expect(OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term)).to eq 'namePart[@type="termsOfAddress"]'
     end
     it "should support mappers without namespaces" do
       @test_term.namespace_prefix = nil
-      OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term).should == 'namePart[@type="termsOfAddress"]'
+      expect(OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term)).to eq 'namePart[@type="termsOfAddress"]'
     end
     it "should not use a namespace for a path set to text() and should include normalize-space to ignore white space" do
       text_term = OM::XML::Term.new(:title_content, :path=>"text()")
-      OM::XML::TermXpathGenerator.generate_relative_xpath(text_term).should == 'text()[normalize-space(.)]'
+      expect(OM::XML::TermXpathGenerator.generate_relative_xpath(text_term)).to eq 'text()[normalize-space(.)]'
     end
     it "should set a 'not' predicate if the attribute value is :none" do
-       OM::XML::TermXpathGenerator.generate_relative_xpath(@test_none_attribute_value).should == 'namePart[not(@type)]'
+       expect(OM::XML::TermXpathGenerator.generate_relative_xpath(@test_none_attribute_value)).to eq 'namePart[not(@type)]'
     end
 
   end
 
   describe "generate_absolute_xpath" do
     it "should generate an absolute xpath based on the given mapper" do
-      OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_term).should == '//namePart[@type="termsOfAddress"]'
+      expect(OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_term)).to eq '//namePart[@type="termsOfAddress"]'
     end
     it "should prepend the xpath for any parent nodes" do
       mock_parent_mapper = double("Term", :xpath_absolute=>'//name[@type="conference"]/role')
       @test_role_text.stub(:parent => mock_parent_mapper)
-      OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_role_text).should == '//name[@type="conference"]/role/roleTerm[@type="text"]'
+      expect(OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_role_text)).to eq '//name[@type="conference"]/role/roleTerm[@type="text"]'
     end
   end
 
   describe "generate_constrained_xpath" do
     it "should generate a constrained xpath based on the given mapper" do
-      OM::XML::TermXpathGenerator.generate_constrained_xpath(@test_term).should == '//namePart[@type="termsOfAddress" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
+      expect(OM::XML::TermXpathGenerator.generate_constrained_xpath(@test_term)).to eq '//namePart[@type="termsOfAddress" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
     end
   end
 
   it "should support mappers without namespaces" do
     @test_term.namespace_prefix = nil
-    OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term).should == 'namePart[@type="termsOfAddress"]'
-    OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_term).should == '//namePart[@type="termsOfAddress"]'
-    OM::XML::TermXpathGenerator.generate_constrained_xpath(@test_term).should == '//namePart[@type="termsOfAddress" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
+    expect(OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term)).to eq 'namePart[@type="termsOfAddress"]'
+    expect(OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_term)).to eq '//namePart[@type="termsOfAddress"]'
+    expect(OM::XML::TermXpathGenerator.generate_constrained_xpath(@test_term)).to eq '//namePart[@type="termsOfAddress" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
   end
 
   describe "generate_xpath_with_indexes" do
@@ -92,15 +92,15 @@ describe "OM::XML::TermXpathGeneratorSpec" do
       generated_xpath = OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology,
                                                     :person, {:first_name=>"Tim", :family_name=>"Berners-Lee"} )
       # expect an xpath that looks like this: '//oxns:name[@type="personal" and contains(oxns:namePart[@type="family"], "Berners-Lee") and contains(oxns:namePart[@type="given"], "Tim")]'
-      generated_xpath.should match( /\/\/oxns:name\[@type=\"personal\".*and oxns:namePart\[@type=\"given\"\]\[text\(\)=\"Tim\"\].*\]/ )
-      generated_xpath.should match( /\/\/oxns:name\[@type=\"personal\".*and oxns:namePart\[@type=\"family\"\]\[text\(\)=\"Berners-Lee\"\].*\]/ )
+      expect(generated_xpath).to match( /\/\/oxns:name\[@type=\"personal\".*and oxns:namePart\[@type=\"given\"\]\[text\(\)=\"Tim\"\].*\]/ )
+      expect(generated_xpath).to match( /\/\/oxns:name\[@type=\"personal\".*and oxns:namePart\[@type=\"family\"\]\[text\(\)=\"Berners-Lee\"\].*\]/ )
     end
 
     it "should find matching nodes" do
       ng = Nokogiri::XML(fixture( File.join("test_dummy_mods.xml")))
       generated_xpath = OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology,
                                                     :person, {:first_name=>"Tim", :family_name=>"Berners-Lee"} )
-      ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3").to_xml.should be_equivalent_to <<EOF
+      expect(ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3").to_xml).to be_equivalent_to <<EOF
       <ns3:name type="personal">
           <ns3:namePart type="family">Berners-Lee</ns3:namePart>
           <ns3:namePart type="given">Tim</ns3:namePart>
@@ -112,33 +112,33 @@ describe "OM::XML::TermXpathGeneratorSpec" do
 EOF
       generated_xpath = OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology,
                                                     :person, {:first_name=>"Tim", :family_name=>"Berners"} )
-      ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3").should be_empty 
+      expect(ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3")).to be_empty 
       generated_xpath = OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology,
                                                     :person, {:first_name=>"Frank", :family_name=>"Berners-Lee"} )
-      ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3").should be_empty 
+      expect(ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3")).to be_empty 
 
       generated_xpath = OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology,
                                                      :person, {:first_name=>"Tim", :family_name=>"Howard"} )
-      ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3").should be_empty 
+      expect(ng.xpath(generated_xpath, 'oxns' => "http://www.loc.gov/mods/v3")).to be_empty 
 
     end
     it "should support xpath queries as argument" do
-      OM::XML::TermXpathGenerator.generate_xpath_with_indexes(@sample_terminology, '//oxns:name[@type="personal"][1]/oxns:namePart').should == '//oxns:name[@type="personal"][1]/oxns:namePart'
+      expect(OM::XML::TermXpathGenerator.generate_xpath_with_indexes(@sample_terminology, '//oxns:name[@type="personal"][1]/oxns:namePart')).to eq '//oxns:name[@type="personal"][1]/oxns:namePart'
     end
     it "should return the xpath of the terminology's root node if term pointer is nil" do
-      OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology, nil ).should == @sample_terminology.root_terms.first.xpath
+      expect(OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology, nil )).to eq @sample_terminology.root_terms.first.xpath
     end
     it "should return / if term pointer is nil and the terminology does not have a root term defined" do
-      OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @rootless_terminology, nil ).should == "/"
+      expect(OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @rootless_terminology, nil )).to eq "/"
     end
     it "should destringify term pointers before using them" do
-      generated_xpath = OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology, {"person"=>"1"}, "first_name" ).should == '//oxns:name[@type="personal"][2]/oxns:namePart[@type="given"]'
+      expect(OM::XML::TermXpathGenerator.generate_xpath_with_indexes( @sample_terminology, {"person"=>"1"}, "first_name" )).to eq '//oxns:name[@type="personal"][2]/oxns:namePart[@type="given"]'
       ### Last argument is a filter, we are passing no filters
-      @sample_terminology.xpath_with_indexes(:name, {:family_name=>1},{}).should == '//oxns:name/oxns:namePart[@type="family"][2]'
+      expect(@sample_terminology.xpath_with_indexes(:name, {:family_name=>1},{})).to eq '//oxns:name/oxns:namePart[@type="family"][2]'
     end
     it "should warn about indexes on a proxy" do
       Logger.any_instance.should_receive(:warn).with("You attempted to call an index value of 1 on the term \":family_name\". However \":family_name\" is a proxy so we are ignoring the index. See https://jira.duraspace.org/browse/HYDRA-643")
-      @sample_terminology.xpath_with_indexes({:family_name=>1}).should == "//oxns:name/oxns:namePart[@type=\"family\"]"
+      expect(@sample_terminology.xpath_with_indexes({:family_name=>1})).to eq "//oxns:name/oxns:namePart[@type=\"family\"]"
     end
   end
 
@@ -146,17 +146,14 @@ EOF
     skip "need to implement mapper_set first"
     #@test_term_with_default_path = OM::XML::Term.new(:volume, :path=>"detail", :attributes=>{:type=>"volume"}, :default_content_path=>"number")
 
-    OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term_with_default_path).should == 'oxns:detail[@type="volume"]'
-    OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_term_with_default_path).should == '//oxns:detail[@type="volume"]'
-    OM::XML::TermXpathGenerator.generate_constrained_xpath(@test_term_with_default_path).should == '//oxns:detail[contains(oxns:number[@type="volume"], "#{constraint_value}")]'.gsub('"', '\"')
+    expect(OM::XML::TermXpathGenerator.generate_relative_xpath(@test_term_with_default_path)).to eq 'oxns:detail[@type="volume"]'
+    expect(OM::XML::TermXpathGenerator.generate_absolute_xpath(@test_term_with_default_path)).to eq '//oxns:detail[@type="volume"]'
+    expect(OM::XML::TermXpathGenerator.generate_constrained_xpath(@test_term_with_default_path)).to eq '//oxns:detail[contains(oxns:number[@type="volume"], "#{constraint_value}")]'.gsub('"', '\"')
   end
 
   it "should default to using an inherited namspace prefix" do
-
     term = @sample_terminology.retrieve_term(:person, :first_name)
-    OM::XML::TermXpathGenerator.generate_absolute_xpath(term).should == "//oxns:name[@type=\"personal\"]/oxns:namePart[@type=\"given\"]"
-
-
+    expect(OM::XML::TermXpathGenerator.generate_absolute_xpath(term)).to eq "//oxns:name[@type=\"personal\"]/oxns:namePart[@type=\"given\"]"
   end
 
 end

--- a/spec/unit/terminology_builder_spec.rb
+++ b/spec/unit/terminology_builder_spec.rb
@@ -75,41 +75,42 @@ describe "OM::XML::Terminology::Builder" do
       end 
 
       terminology = t_builder.build 
-      terminology.retrieve_term(:title).should be_kind_of OM::XML::NamedTermProxy
-      terminology.retrieve_term(:title).index_as.should == [:facetable, :not_searchable]
-      terminology.retrieve_term(:title_info, :main_title).index_as.should == []
-      terminology.xpath_for(:title).should == '//oxns:titleInfo/oxns:title'
-      terminology.xpath_with_indexes({:title=>0}).should == "//oxns:titleInfo/oxns:title"
+      expect(terminology.retrieve_term(:title)).to be_kind_of OM::XML::NamedTermProxy
+      expect(terminology.retrieve_term(:title).index_as).to eq [:facetable, :not_searchable]
+      expect(terminology.retrieve_term(:title_info, :main_title).index_as).to eq []
+      expect(terminology.xpath_for(:title)).to eq '//oxns:titleInfo/oxns:title'
+      expect(terminology.xpath_with_indexes({:title=>0})).to eq "//oxns:titleInfo/oxns:title"
       # @builder_with_block.build.xpath_for_pointer(:issue).should == '//oxns:part'
       # terminology.xpath_for_pointer(:title).should == '//oxns:titleInfo/oxns:title'
     end
     
     describe '#new' do
       it "should return an instance of OM::XML::Terminology::Builder" do
-        OM::XML::Terminology::Builder.new.should be_instance_of OM::XML::Terminology::Builder
+        expect(OM::XML::Terminology::Builder.new).to be_instance_of OM::XML::Terminology::Builder
       end
       it "should process the input block, creating a new Term Builder for each entry and its children" do
         expected_root_terms = [:mods, :title_info, :issue, :person, :name, :journal, :role]
         expected_root_terms.each do |name|
-          @builder_with_block.term_builders.should have_key(name)
+          expect(@builder_with_block.term_builders).to have_key(name)
         end
-        @builder_with_block.term_builders.length.should == expected_root_terms.length
         
-        @builder_with_block.term_builders[:journal].should be_instance_of OM::XML::Term::Builder
-        @builder_with_block.term_builders[:journal].settings[:path].should == "relatedItem"
-        @builder_with_block.term_builders[:journal].settings[:attributes].should == {:type=>"host"}
+        expect(@builder_with_block.term_builders.length).to eq expected_root_terms.length
+        
+        expect(@builder_with_block.term_builders[:journal]).to be_instance_of OM::XML::Term::Builder
+        expect(@builder_with_block.term_builders[:journal].settings[:path]).to eq "relatedItem"
+        expect(@builder_with_block.term_builders[:journal].settings[:attributes]).to eq({:type=>"host"})
 
-        @builder_with_block.term_builders[:journal].children[:issn].should be_instance_of OM::XML::Term::Builder
-        @builder_with_block.term_builders[:journal].children[:issn].settings[:path].should == "identifier"
-        @builder_with_block.term_builders[:journal].children[:issn].settings[:attributes].should == {:type=>"issn"}
+        expect(@builder_with_block.term_builders[:journal].children[:issn]).to be_instance_of OM::XML::Term::Builder
+        expect(@builder_with_block.term_builders[:journal].children[:issn].settings[:path]).to eq "identifier"
+        expect(@builder_with_block.term_builders[:journal].children[:issn].settings[:attributes]).to eq({:type=>"issn"})
       end
       it "should clip the underscore off the end of any Term names" do
-        @builder_with_block.term_builders[:name].should be_instance_of OM::XML::Term::Builder
-        @builder_with_block.term_builders[:name].name.should == :name
+        expect(@builder_with_block.term_builders[:name]).to be_instance_of OM::XML::Term::Builder
+        expect(@builder_with_block.term_builders[:name].name).to eq :name
 
-        @builder_with_block.term_builders[:name].children[:date].should be_instance_of OM::XML::Term::Builder
-        @builder_with_block.term_builders[:name].children[:date].settings[:path].should == "namePart"
-        @builder_with_block.term_builders[:name].children[:date].settings[:attributes].should == {:type=>"date"}
+        expect(@builder_with_block.term_builders[:name].children[:date]).to be_instance_of OM::XML::Term::Builder
+        expect(@builder_with_block.term_builders[:name].children[:date].settings[:path]).to eq "namePart"
+        expect(@builder_with_block.term_builders[:name].children[:date].settings[:attributes]).to eq({:type=>"date"})
       end
     end
     
@@ -117,42 +118,44 @@ describe "OM::XML::Terminology::Builder" do
       it "should let you load mappings from an xml file" do
         skip
         vocab = OM::XML::Terminology.from_xml( fixture("sample_mappings.xml") )
-        vocab.should be_instance_of OM::XML::Terminology
-        vocab.mappers.should == {}
+        expect(vocab).to be_instance_of OM::XML::Terminology
+        expect(vocab.mappers).to eq({})
       end
     end
     
     describe ".retrieve_term_builder" do
       it "should support looking up Term Builders by pointer" do
         expected = @builder_with_block.term_builders[:name].children[:date]
-        @builder_with_block.retrieve_term_builder(:name, :date).should == expected
+        expect(@builder_with_block.retrieve_term_builder(:name, :date)).to eq expected
       end
     end
     
     describe "build" do
       it "should generate the new Terminology, calling .build on its Term builders"
       it "should resolve :refs" do
-        @builder_with_block.retrieve_term_builder(:name, :role).settings[:ref].should == [:role]
-        @builder_with_block.retrieve_term_builder(:role).children[:text].should be_instance_of OM::XML::Term::Builder
+        expect(@builder_with_block.retrieve_term_builder(:name, :role).settings[:ref]).to eq [:role]
+        expect(@builder_with_block.retrieve_term_builder(:role).children[:text]).to be_instance_of OM::XML::Term::Builder
         
         built_terminology = @builder_with_block.build
         
-        built_terminology.retrieve_term(:name, :role, :text).should be_instance_of OM::XML::Term
-        built_terminology.retrieve_term(:name, :role, :text).path.should == "roleTerm"
-        built_terminology.retrieve_term(:name, :role, :text).attributes.should == {:type=>"text"}
+        expect(built_terminology.retrieve_term(:name, :role, :text)).to be_instance_of OM::XML::Term
+        expect(built_terminology.retrieve_term(:name, :role, :text).path).to eq "roleTerm"
+        expect(built_terminology.retrieve_term(:name, :role, :text).attributes).to eq({:type=>"text"})
       end
       it "should put copies of the entire terminology under any root terms" do
-        @builder_with_block.root_term_builders.should include(@builder_with_block.retrieve_term_builder(:mods))
+        expect(@builder_with_block.root_term_builders).to include(@builder_with_block.retrieve_term_builder(:mods))
         
         built_terminology = @builder_with_block.build
         expected_keys = [:title_info, :issue, :person, :name, :journal, :role]
         
-        built_terminology.retrieve_term(:mods).children.length.should == expected_keys.length
+        expect(built_terminology.retrieve_term(:mods).children.length).to eq expected_keys.length
+
         expected_keys.each do |key|
-          built_terminology.retrieve_term(:mods).children.keys.should include(key)
+          expect(built_terminology.retrieve_term(:mods).children.keys).to include(key)
         end
-        built_terminology.retrieve_term(:mods, :name, :role, :text).should be_instance_of OM::XML::Term
-        built_terminology.retrieve_term(:mods, :person, :role, :text).should be_instance_of OM::XML::Term
+        
+        expect(built_terminology.retrieve_term(:mods, :name, :role, :text)).to be_instance_of OM::XML::Term
+        expect(built_terminology.retrieve_term(:mods, :person, :role, :text)).to be_instance_of OM::XML::Term
 
       end
     end
@@ -162,42 +165,42 @@ describe "OM::XML::Terminology::Builder" do
         skip
         
         result = @test_builder.insert_mapper(:name_, :namePart).index_as([:facetable, :searchable, :sortable, :displayable]).required(true).type(:text)  
-        @test_builder.mapper_builders(:name_, :namePart).should == result
-        result.should be_instance_of OM::XML::Mapper::Builder
+        expect(@test_builder.mapper_builders(:name_, :namePart)).to eq result
+        expect(result).to be_instance_of OM::XML::Mapper::Builder
       end
     end
     
     describe ".root" do
       it "should accept options for the root node, such as namespace(s)  and schema and those values should impact the resulting Terminology" do
         root_term_builder = @test_builder.root(:path=>"mods", :xmlns => 'one:two', 'xmlns:foo' => 'bar', :schema=>"http://www.loc.gov/standards/mods/v3/mods-3-2.xsd")
-        root_term_builder.settings[:is_root_term].should == true
+        expect(root_term_builder.settings[:is_root_term]).to  be true
         
-        @test_builder.schema.should == "http://www.loc.gov/standards/mods/v3/mods-3-2.xsd"
-        @test_builder.namespaces.should == { "oxns"=>"one:two", 'xmlns' => 'one:two', 'xmlns:foo' => 'bar' }
-        @test_builder.term_builders[:mods].should == root_term_builder      
+        expect(@test_builder.schema).to eq "http://www.loc.gov/standards/mods/v3/mods-3-2.xsd"
+        expect(@test_builder.namespaces).to eq({ "oxns"=>"one:two", 'xmlns' => 'one:two', 'xmlns:foo' => 'bar' })
+        expect(@test_builder.term_builders[:mods]).to eq root_term_builder      
         
         terminology = @test_builder.build
-        terminology.schema.should == "http://www.loc.gov/standards/mods/v3/mods-3-2.xsd"
-        terminology.namespaces.should == { "oxns"=>"one:two", 'xmlns' => 'one:two', 'xmlns:foo' => 'bar' }
+        expect(terminology.schema).to eq "http://www.loc.gov/standards/mods/v3/mods-3-2.xsd"
+        expect(terminology.namespaces).to eq({ "oxns"=>"one:two", 'xmlns' => 'one:two', 'xmlns:foo' => 'bar' })
       end
       it "should create an explicit term correspoinding to the root node and pass any additional settings into that term" do
         @test_builder.root(:path=>"fwoop", :xmlns => 'one:two', 'xmlns:foo' => 'bar', :index_as=>[:not_searchable], :namespace_prefix=>"foox")
         terminology = @test_builder.build
         term = terminology.retrieve_term(:fwoop)
-        term.should be_instance_of OM::XML::Term
-        term.is_root_term?.should == true
-        term.index_as.should == [:not_searchable]        
-        term.namespace_prefix.should == "foox"   
+        expect(term).to be_instance_of OM::XML::Term
+        expect(term.is_root_term?).to eq true
+        expect(term.index_as).to eq [:not_searchable]        
+        expect(term.namespace_prefix).to eq "foox"   
       end
       it "should work within a builder block" do
-        @builder_with_block.term_builders[:mods].settings[:is_root_term].should == true
+        expect(@builder_with_block.term_builders[:mods].settings[:is_root_term]).to eq true
       end
     end
     
     describe ".root_term_builders" do
       it "should return the terms that have been marked root" do
-        @builder_with_block.root_term_builders.length.should == 1
-        @builder_with_block.root_term_builders.first.should == @builder_with_block.term_builders[:mods]
+        expect(@builder_with_block.root_term_builders.length).to eq 1
+        expect(@builder_with_block.root_term_builders.first).to eq @builder_with_block.term_builders[:mods]
       end
     end
     

--- a/spec/unit/terminology_spec.rb
+++ b/spec/unit/terminology_spec.rb
@@ -89,90 +89,90 @@ describe "OM::XML::Terminology" do
 
   describe "namespaceless terminologies" do
     it "should generate xpath queries without namespaces" do
-      @namespaceless_terminology.xpath_for(:to).should == "//to"
-      @namespaceless_terminology.xpath_for(:note, :from).should == "//note/from"
+      expect(@namespaceless_terminology.xpath_for(:to)).to eq "//to"
+      expect(@namespaceless_terminology.xpath_for(:note, :from)).to eq "//note/from"
     end
 
     it "should work with xml documents that have no namespaces" do
-      @namespaceless_doc.from.first.should == "Jani"
-      @namespaceless_doc.to.should == ["Tove"]
+      expect(@namespaceless_doc.from.first).to eq "Jani"
+      expect(@namespaceless_doc.to).to eq ["Tove"]
     end
   end
 
   describe "basics" do
 
     it "constructs xpath queries for finding properties" do
-      @test_full_terminology.retrieve_term(:name).xpath.should == '//oxns:name'
-      @test_full_terminology.retrieve_term(:name).xpath_relative.should == 'oxns:name'
+      expect(@test_full_terminology.retrieve_term(:name).xpath).to eq '//oxns:name'
+      expect(@test_full_terminology.retrieve_term(:name).xpath_relative).to eq 'oxns:name'
 
-      @test_full_terminology.retrieve_term(:person).xpath.should == '//oxns:name[@type="personal"]'
-      @test_full_terminology.retrieve_term(:person).xpath_relative.should == 'oxns:name[@type="personal"]'
-      @test_full_terminology.retrieve_term(:person, :person_id).xpath_relative.should == 'oxns:namePart[not(@type)]'
+      expect(@test_full_terminology.retrieve_term(:person).xpath).to eq '//oxns:name[@type="personal"]'
+      expect(@test_full_terminology.retrieve_term(:person).xpath_relative).to eq 'oxns:name[@type="personal"]'
+      expect(@test_full_terminology.retrieve_term(:person, :person_id).xpath_relative).to eq 'oxns:namePart[not(@type)]'
     end
 
     it "should expand proxy and get sub terms" do
-      @test_full_terminology.retrieve_node(:title, :main_title_lang).xpath.should == '//oxns:titleInfo/oxns:title/@xml:lang'
+      expect(@test_full_terminology.retrieve_node(:title, :main_title_lang).xpath).to eq '//oxns:titleInfo/oxns:title/@xml:lang'
       ### retrieve_term() will not cross proxies
-      @test_full_terminology.retrieve_term(:title_info, :main_title, :main_title_lang).xpath.should == '//oxns:titleInfo/oxns:title/@xml:lang'
+      expect(@test_full_terminology.retrieve_term(:title_info, :main_title, :main_title_lang).xpath).to eq '//oxns:titleInfo/oxns:title/@xml:lang'
     end
 
     it "constructs templates for value-driven searches" do
-      @test_full_terminology.retrieve_term(:name).xpath_constrained.should == '//oxns:name[contains(., "#{constraint_value}")]'.gsub('"', '\"')
-      @test_full_terminology.retrieve_term(:person).xpath_constrained.should == '//oxns:name[@type="personal" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
+      expect(@test_full_terminology.retrieve_term(:name).xpath_constrained).to eq '//oxns:name[contains(., "#{constraint_value}")]'.gsub('"', '\"')
+      expect(@test_full_terminology.retrieve_term(:person).xpath_constrained).to eq '//oxns:name[@type="personal" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
 
       # Example of how you could use these templates:
       constraint_value = "SAMPLE CONSTRAINT VALUE"
       constrained_query = eval( '"' + @test_full_terminology.retrieve_term(:person).xpath_constrained + '"' )
-      constrained_query.should == '//oxns:name[@type="personal" and contains(., "SAMPLE CONSTRAINT VALUE")]'
+      expect(constrained_query).to eq '//oxns:name[@type="personal" and contains(., "SAMPLE CONSTRAINT VALUE")]'
     end
 
     it "constructs xpath queries & templates for nested terms" do
       name_date_term = @test_full_terminology.retrieve_term(:name, :date)
-      name_date_term.xpath.should == '//oxns:name/oxns:namePart[@type="date"]'
-      name_date_term.xpath_relative.should == 'oxns:namePart[@type="date"]'
-      name_date_term.xpath_constrained.should == '//oxns:name/oxns:namePart[@type="date" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
+      expect(name_date_term.xpath).to eq '//oxns:name/oxns:namePart[@type="date"]'
+      expect(name_date_term.xpath_relative).to eq 'oxns:namePart[@type="date"]'
+      expect(name_date_term.xpath_constrained).to eq '//oxns:name/oxns:namePart[@type="date" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
       # name_date_term.xpath_constrained.should == '//oxns:name[contains(oxns:namePart[@type="date"], "#{constraint_value}")]'.gsub('"', '\"')
 
       person_date_term = @test_full_terminology.retrieve_term(:person, :date)
-      person_date_term.xpath.should == '//oxns:name[@type="personal"]/oxns:namePart[@type="date"]'
-      person_date_term.xpath_relative.should == 'oxns:namePart[@type="date"]'
-      person_date_term.xpath_constrained.should == '//oxns:name[@type="personal"]/oxns:namePart[@type="date" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
+      expect(person_date_term.xpath).to eq '//oxns:name[@type="personal"]/oxns:namePart[@type="date"]'
+      expect(person_date_term.xpath_relative).to eq 'oxns:namePart[@type="date"]'
+      expect(person_date_term.xpath_constrained).to eq '//oxns:name[@type="personal"]/oxns:namePart[@type="date" and contains(., "#{constraint_value}")]'.gsub('"', '\"')
       # person_date_term.xpath_constrained.should == '//oxns:name[@type="personal" and contains(oxns:namePart[@type="date"], "#{constraint_value}")]'.gsub('"', '\"')
     end
 
     it "supports subelements that are specified using a :ref" do
       role_term = @test_full_terminology.retrieve_term(:name, :role)
-      role_term.xpath.should == '//oxns:name/oxns:role'
-      role_term.xpath_relative.should == 'oxns:role'
-      role_term.xpath_constrained.should == '//oxns:name/oxns:role[contains(., "#{constraint_value}")]'.gsub('"', '\"')
+      expect(role_term.xpath).to eq '//oxns:name/oxns:role'
+      expect(role_term.xpath_relative).to eq 'oxns:role'
+      expect(role_term.xpath_constrained).to eq '//oxns:name/oxns:role[contains(., "#{constraint_value}")]'.gsub('"', '\"')
       # role_term.xpath_constrained.should == '//oxns:name[contains(oxns:role/oxns:roleTerm, "#{constraint_value}")]'.gsub('"', '\"')
     end
 
     describe "treating attributes as properties" do
       it "should build correct xpath" do    
         language_term = @test_full_terminology.retrieve_term(:title_info, :language)
-        language_term.xpath.should == '//oxns:titleInfo/@lang'
-        language_term.xpath_relative.should == '@lang'
-        language_term.xpath_constrained.should == '//oxns:titleInfo/@lang[contains(., "#{constraint_value}")]'.gsub('"', '\"')
+        expect(language_term.xpath).to eq '//oxns:titleInfo/@lang'
+        expect(language_term.xpath_relative).to eq '@lang'
+        expect(language_term.xpath_constrained).to eq '//oxns:titleInfo/@lang[contains(., "#{constraint_value}")]'.gsub('"', '\"')
       end
     end
 
     it "should support deep nesting of properties" do
       volume_term = @test_full_terminology.retrieve_term(:journal, :issue, :volume)
-      volume_term.xpath.should == "//oxns:relatedItem[@type=\"host\"]/oxns:part/oxns:detail[@type=\"volume\"]"
-      volume_term.xpath_relative.should == "oxns:detail[@type=\"volume\"]"
+      expect(volume_term.xpath).to eq "//oxns:relatedItem[@type=\"host\"]/oxns:part/oxns:detail[@type=\"volume\"]"
+      expect(volume_term.xpath_relative).to eq "oxns:detail[@type=\"volume\"]"
       # volume_term.xpath_constrained.should == "//oxns:part[contains(oxns:detail[@type=\\\"volume\\\"], \\\"\#{constraint_value}\\\")]"
-      volume_term.xpath_constrained.should == '//oxns:relatedItem[@type="host"]/oxns:part/oxns:detail[@type="volume" and contains(oxns:number, "#{constraint_value}")]'.gsub('"', '\"')
+      expect(volume_term.xpath_constrained).to eq '//oxns:relatedItem[@type="host"]/oxns:part/oxns:detail[@type="volume" and contains(oxns:number, "#{constraint_value}")]'.gsub('"', '\"')
     end
 
     it "should not overwrite default property info when adding a variant property" do
       name_term = @test_full_terminology.retrieve_term(:name)
       person_term = @test_full_terminology.retrieve_term(:person)
 
-      name_term.should_not equal(person_term)
-      name_term.xpath.should_not equal(person_term.xpath)
-      name_term.children.should_not equal(person_term.children)
-      name_term.children[:date].xpath_constrained.should_not equal(person_term.children[:date].xpath_constrained)
+      expect(name_term).not_to equal(person_term)
+      expect(name_term.xpath).not_to equal(person_term.xpath)
+      expect(name_term.children).not_to equal(person_term.children)
+      expect(name_term.children[:date].xpath_constrained).not_to equal(person_term.children[:date].xpath_constrained)
     end
 
   end
@@ -181,8 +181,8 @@ describe "OM::XML::Terminology" do
     it "should let you load mappings from an xml file" do
       skip
       vocab = OM::XML::Terminology.from_xml( fixture("sample_mappings.xml") )
-      vocab.should be_instance_of OM::XML::Terminology
-      vocab.mappers.should == {}
+      expect(vocab).to be_instance_of OM::XML::Terminology
+      expect(vocab).mappers.to eq({})
     end
   end
 
@@ -195,46 +195,46 @@ describe "OM::XML::Terminology" do
 
   describe ".has_term?" do
     it "should return true if the specified term does exist in the terminology" do
-      @test_full_terminology.has_term?(:journal,:issue,:end_page).should be true
+      expect(@test_full_terminology.has_term?(:journal,:issue,:end_page)).to be true
     end
     it "should support term_pointers with array indexes in them (ignoring the indexes)" do
-      @test_full_terminology.has_term?(:title_info, :main_title).should be true
-      @test_full_terminology.has_term?({:title_info=>"0"}, :main_title).should be true
+      expect(@test_full_terminology.has_term?(:title_info, :main_title)).to be true
+      expect(@test_full_terminology.has_term?({:title_info=>"0"}, :main_title)).to be true
     end
     it "should return false if the specified term does not exist in the terminology" do
-      @test_full_terminology.has_term?(:name, :date, :nonexistentTerm, :anotherTermName).should be_falsey
+      expect(@test_full_terminology.has_term?(:name, :date, :nonexistentTerm, :anotherTermName)).to be_falsey
     end
   end
 
   describe ".retrieve_term" do
     it "should return the mapper identified by the given pointer" do
       term = @test_terminology.retrieve_term(:name, :namePart)
-      term.should == @test_terminology.terms[:name].children[:namePart]
-      term.should == @test_child_term
+      expect(term.should).to eq @test_terminology.terms[:name].children[:namePart]
+      expect(term.should).to eq @test_child_term
     end
     it "should build complete terminologies" do
-      @test_full_terminology.retrieve_term(:name, :date).should be_instance_of OM::XML::Term
-      @test_full_terminology.retrieve_term(:name, :date).path.should == 'namePart'
-      @test_full_terminology.retrieve_term(:name, :date).attributes.should == {:type=>"date"}
-      @test_full_terminology.retrieve_term(:name, :affiliation).path.should == 'affiliation'
-      @test_full_terminology.retrieve_term(:name, :date).xpath.should == '//oxns:name/oxns:namePart[@type="date"]'
+      expect(@test_full_terminology.retrieve_term(:name, :date)).to be_instance_of OM::XML::Term
+      expect(@test_full_terminology.retrieve_term(:name, :date).path).to eq 'namePart'
+      expect(@test_full_terminology.retrieve_term(:name, :date).attributes).to eq({:type=>"date"})
+      expect(@test_full_terminology.retrieve_term(:name, :affiliation).path).to eq('affiliation')
+      expect(@test_full_terminology.retrieve_term(:name, :date).xpath).to eq('//oxns:name/oxns:namePart[@type="date"]')
     end
     it "should support looking up variant Terms" do
-      @test_full_terminology.retrieve_term(:person).path.should == 'name'
-      @test_full_terminology.retrieve_term(:person).attributes.should == {:type=>"personal"}
-      @test_full_terminology.retrieve_term(:person, :affiliation).path.should == 'affiliation'
-      @test_full_terminology.retrieve_term(:person, :date).xpath.should == '//oxns:name[@type="personal"]/oxns:namePart[@type="date"]'
+      expect(@test_full_terminology.retrieve_term(:person).path).to eq('name')
+      expect(@test_full_terminology.retrieve_term(:person).attributes).to eq({:type=>"personal"})
+      expect(@test_full_terminology.retrieve_term(:person, :affiliation).path).to eq('affiliation') 
+      expect(@test_full_terminology.retrieve_term(:person, :date).xpath).to eq('//oxns:name[@type="personal"]/oxns:namePart[@type="date"]')
     end
     it "should support including root terms in pointer" do
-      @test_full_terminology.retrieve_term(:mods).should be_instance_of OM::XML::Term
-      @test_full_terminology.retrieve_term(:mods, :name, :date).should be_instance_of OM::XML::Term
-      @test_full_terminology.retrieve_term(:mods, :name, :date).path.should == 'namePart'
-      @test_full_terminology.retrieve_term(:mods, :name, :date).attributes.should == {:type=>"date"}
-      @test_full_terminology.retrieve_term(:mods, :name, :date).xpath.should == '//oxns:mods/oxns:name/oxns:namePart[@type="date"]'
+      expect(@test_full_terminology.retrieve_term(:mods)).to be_instance_of OM::XML::Term
+      expect(@test_full_terminology.retrieve_term(:mods, :name, :date)).to be_instance_of OM::XML::Term
+      expect(@test_full_terminology.retrieve_term(:mods, :name, :date).path).to eq 'namePart'
+      expect(@test_full_terminology.retrieve_term(:mods, :name, :date).attributes).to eq({:type=>"date"})
+      expect(@test_full_terminology.retrieve_term(:mods, :name, :date).xpath).to eq '//oxns:mods/oxns:name/oxns:namePart[@type="date"]'
     end
 
     it "should raise an informative error if the desired Term doesn't exist" do
-      lambda { @test_full_terminology.retrieve_term(:name, :date, :nonexistentTerm, :anotherTermName) }.should raise_error(OM::XML::Terminology::BadPointerError, "You attempted to retrieve a Term using this pointer: [:name, :date, :nonexistentTerm, :anotherTermName] but no Term exists at that location. Everything is fine until \":nonexistentTerm\", which doesn't exist.")
+      expect(lambda { @test_full_terminology.retrieve_term(:name, :date, :nonexistentTerm, :anotherTermName) }).to raise_error(OM::XML::Terminology::BadPointerError, "You attempted to retrieve a Term using this pointer: [:name, :date, :nonexistentTerm, :anotherTermName] but no Term exists at that location. Everything is fine until \":nonexistentTerm\", which doesn't exist.")
     end
   end
 
@@ -244,7 +244,7 @@ describe "OM::XML::Terminology" do
       # conference_mapper = TerminologyTest.retrieve_mapper(:conference)
       # role_mapper =  TerminologyTest.retrieve_mapper(:conference, :role)
       # text_mapper = TerminologyTest.retrieve_mapper(:conference, :role, :text)
-      TerminologyTest.term_xpath({:conference=>0}, {:role=>1}, :text ).should == '//oxns:name[@type="conference"][1]/oxns:role[2]/oxns:roleTerm[@type="text"]'
+      expect(TerminologyTest.term_xpath({:conference=>0}, {:role=>1}, :text )).to eq '//oxns:name[@type="conference"][1]/oxns:role[2]/oxns:roleTerm[@type="text"]'
       # OM::XML::TermXpathGenerator.expects(:generate_absolute_xpath).with({conference_mapper=>0}, {role_mapper=>1}, text_mapper)
     end
   end
@@ -252,40 +252,40 @@ describe "OM::XML::Terminology" do
   describe ".xpath_for" do
 
     it "should retrieve the generated xpath query to match your desires" do
-      @test_full_terminology.xpath_for(:person).should == '//oxns:name[@type="personal"]'
+      expect(@test_full_terminology.xpath_for(:person)).to eq '//oxns:name[@type="personal"]'
 
-      @test_full_terminology.xpath_for(:person, "Beethoven, Ludwig van").should == '//oxns:name[@type="personal" and contains(., "Beethoven, Ludwig van")]'
+      expect(@test_full_terminology.xpath_for(:person, "Beethoven, Ludwig van")).to eq '//oxns:name[@type="personal" and contains(., "Beethoven, Ludwig van")]'
 
-      @test_full_terminology.xpath_for(:person, :date).should == '//oxns:name[@type="personal"]/oxns:namePart[@type="date"]'
+      expect(@test_full_terminology.xpath_for(:person, :date)).to eq '//oxns:name[@type="personal"]/oxns:namePart[@type="date"]'
 
-      @test_full_terminology.xpath_for(:person, :date, "2010").should == '//oxns:name[@type="personal"]/oxns:namePart[@type="date" and contains(., "2010")]'
+      expect(@test_full_terminology.xpath_for(:person, :date, "2010")).to eq '//oxns:name[@type="personal"]/oxns:namePart[@type="date" and contains(., "2010")]'
 
-      @test_full_terminology.xpath_for(:person, :person_id).should == '//oxns:name[@type="personal"]/oxns:namePart[not(@type)]'
+      expect(@test_full_terminology.xpath_for(:person, :person_id)).to eq '//oxns:name[@type="personal"]/oxns:namePart[not(@type)]'
 
     end
 
     it "should support including root terms in term pointer" do
-      @test_full_terminology.xpath_for(:mods, :person).should == '//oxns:mods/oxns:name[@type="personal"]'
-      @test_full_terminology.xpath_for(:mods, :person, "Beethoven, Ludwig van").should == '//oxns:mods/oxns:name[@type="personal" and contains(., "Beethoven, Ludwig van")]'
+      expect(@test_full_terminology.xpath_for(:mods, :person)).to eq '//oxns:mods/oxns:name[@type="personal"]'
+      expect(@test_full_terminology.xpath_for(:mods, :person, "Beethoven, Ludwig van")).to eq '//oxns:mods/oxns:name[@type="personal" and contains(., "Beethoven, Ludwig van")]'
     end
 
     it "should support queries with complex constraints" do
       skip
-      @test_full_terminology.xpath_for(:person, {:date=>"2010"}).should == '//oxns:name[@type="personal" and contains(oxns:namePart[@type="date"], "2010")]'
+      expect(@test_full_terminology.xpath_for(:person, {:date=>"2010"})).to eq '//oxns:name[@type="personal" and contains(oxns:namePart[@type="date"], "2010")]'
     end
 
     it "should support queries with multiple complex constraints" do
       skip
-      @test_full_terminology.xpath_for(:person, {:role=>"donor", :last_name=>"Rockefeller"}).should == '//oxns:name[@type="personal" and contains(oxns:role/oxns:roleTerm, "donor") and contains(oxns:namePart[@type="family"], "Rockefeller")]'
+      expect(@test_full_terminology.xpath_for(:person, {:role=>"donor", :last_name=>"Rockefeller"})).to eq '//oxns:name[@type="personal" and contains(oxns:role/oxns:roleTerm, "donor") and contains(oxns:namePart[@type="family"], "Rockefeller")]'
     end
 
     it "should parrot any strings back to you (in case you already have an xpath query)" do
-      @test_full_terminology.xpath_for('//oxns:name[@type="personal"]/oxns:namePart[@type="date"]').should == '//oxns:name[@type="personal"]/oxns:namePart[@type="date"]'
+      expect(@test_full_terminology.xpath_for('//oxns:name[@type="personal"]/oxns:namePart[@type="date"]')).to eq '//oxns:name[@type="personal"]/oxns:namePart[@type="date"]'
     end
 
     it "should traverse named term proxies transparently" do
       proxied_xpath = @test_full_terminology.xpath_for(:journal, :issue, :pages, :start)
-      @test_full_terminology.xpath_for( :journal, :issue, :start_page ).should == proxied_xpath
+      expect(@test_full_terminology.xpath_for( :journal, :issue, :start_page )).to eq proxied_xpath
     end
 
   end
@@ -295,29 +295,29 @@ describe "OM::XML::Terminology" do
       @test_full_terminology.xpath_with_indexes( :title_info ).should == '//oxns:titleInfo'
     end
     it "should support xpath queries as argument" do
-      @test_full_terminology.xpath_with_indexes('//oxns:name[@type="personal"][1]/oxns:namePart').should == '//oxns:name[@type="personal"][1]/oxns:namePart'
+      expect(@test_full_terminology.xpath_with_indexes('//oxns:name[@type="personal"][1]/oxns:namePart')).to eq '//oxns:name[@type="personal"][1]/oxns:namePart'
     end
     # Note: Ruby array indexes begin from 0.  In xpath queries (which start from 1 instead of 0), this will be translated accordingly.
     it "should prepend the xpath for any parent nodes, inserting calls to xpath array lookup where necessary" do
-      @test_full_terminology.xpath_with_indexes( {:conference=>0}, {:role=>1}, :text ).should == '//oxns:name[@type="conference"][1]/oxns:role[2]/oxns:roleTerm[@type="text"]'
+      expect(@test_full_terminology.xpath_with_indexes( {:conference=>0}, {:role=>1}, :text )).to eq '//oxns:name[@type="conference"][1]/oxns:role[2]/oxns:roleTerm[@type="text"]'
     end
     it "should be idempotent" do
-      @test_full_terminology.xpath_with_indexes( *[{:title_info=>2}, :main_title] ).should == "//oxns:titleInfo[3]/oxns:title"
-      @test_full_terminology.xpath_with_indexes( *[{:title_info=>2}, :main_title] ).should == "//oxns:titleInfo[3]/oxns:title"
-      @test_full_terminology.xpath_with_indexes( *[{:title_info=>2}, :main_title] ).should == "//oxns:titleInfo[3]/oxns:title"
+      expect(@test_full_terminology.xpath_with_indexes( *[{:title_info=>2}, :main_title] )).to eq "//oxns:titleInfo[3]/oxns:title"
+      expect(@test_full_terminology.xpath_with_indexes( *[{:title_info=>2}, :main_title] )).to eq "//oxns:titleInfo[3]/oxns:title"
+      expect(@test_full_terminology.xpath_with_indexes( *[{:title_info=>2}, :main_title] )).to eq "//oxns:titleInfo[3]/oxns:title"
     end
     it "should traverse named term proxies transparently" do
       proxied_xpath = @test_full_terminology.xpath_with_indexes(:journal, :issue, :pages, :start)
-      @test_full_terminology.xpath_with_indexes( :journal, :issue, :start_page ).should == proxied_xpath
+      expect(@test_full_terminology.xpath_with_indexes( :journal, :issue, :start_page )).to eq proxied_xpath
     end
   end
 
   describe "#xml_builder_template" do
 
     it "should generate a template call for passing into the builder block (assumes 'xml' as the argument for the block)" do
-      @test_full_terminology.xml_builder_template(:person,:date).should == 'xml.namePart( \'#{builder_new_value}\', \'type\'=>\'date\' )'
-      @test_full_terminology.xml_builder_template(:person,:person_id).should == 'xml.namePart( \'#{builder_new_value}\' )'
-      @test_full_terminology.xml_builder_template(:name,:affiliation).should == 'xml.affiliation( \'#{builder_new_value}\' )'
+      expect(@test_full_terminology.xml_builder_template(:person,:date)).to eq 'xml.namePart( \'#{builder_new_value}\', \'type\'=>\'date\' )'
+      expect(@test_full_terminology.xml_builder_template(:person,:person_id)).to eq 'xml.namePart( \'#{builder_new_value}\' )'
+      expect(@test_full_terminology.xml_builder_template(:name,:affiliation)).to eq 'xml.affiliation( \'#{builder_new_value}\' )'
     end
 
     it "should accept extra options" do
@@ -326,44 +326,44 @@ describe "OM::XML::Terminology" do
       e1 = %q{xml.roleTerm( '#{builder_new_value}', 'type'=>'code', 'authority'=>'marcrelator' )}
       e2 = %q{xml.roleTerm( '#{builder_new_value}', 'authority'=>'marcrelator', 'type'=>'code' )}
       got = @test_full_terminology.xml_builder_template(:role, :code, {:attributes=>{"authority"=>"marcrelator"}} )
-      [e1, e2].should include(got)
+      expect([e1, e2]).to include(got)
       got = @test_full_terminology.xml_builder_template(:person, :role, :code, {:attributes=>{"authority"=>"marcrelator"}} )
-      [e1, e2].should include(got)
+      expect([e1, e2]).to include(got)
     end
 
     it "should work with deeply nested properties" do
-      @test_full_terminology.xml_builder_template(:issue, :volume).should == "xml.detail( \'type\'=>'volume' ) { xml.number( '\#{builder_new_value}' ) }"
-      @test_full_terminology.xml_builder_template(:journal, :issue, :level).should == "xml.detail( \'type\'=>'number' ) { xml.number( '\#{builder_new_value}' ) }"
-      @test_full_terminology.xml_builder_template(:journal, :issue, :volume).should == "xml.detail( \'type\'=>'volume' ) { xml.number( '\#{builder_new_value}' ) }"
-      @test_full_terminology.xml_builder_template(:journal, :issue, :pages, :start).should == "xml.start( '\#{builder_new_value}' )"
+      expect(@test_full_terminology.xml_builder_template(:issue, :volume)).to eq "xml.detail( \'type\'=>'volume' ) { xml.number( '\#{builder_new_value}' ) }"
+      expect(@test_full_terminology.xml_builder_template(:journal, :issue, :level)).to eq "xml.detail( \'type\'=>'number' ) { xml.number( '\#{builder_new_value}' ) }"
+      expect(@test_full_terminology.xml_builder_template(:journal, :issue, :volume)).to eq "xml.detail( \'type\'=>'volume' ) { xml.number( '\#{builder_new_value}' ) }"
+      expect(@test_full_terminology.xml_builder_template(:journal, :issue, :pages, :start)).to eq "xml.start( '\#{builder_new_value}' )"
     end
 
   end
 
   describe "#term_generic_name" do
     it "should generate a generic accessor name based on an array of pointers" do
-      OM::XML::Terminology.term_generic_name( {:conference=>0}, {:role=>1}, :text ).should == "conference_role_text"
-      OM::XML::Terminology.term_generic_name( *[{:conference=>0}, {:role=>1}, :text] ).should == "conference_role_text"
+      expect(OM::XML::Terminology.term_generic_name( {:conference=>0}, {:role=>1}, :text )).to eq "conference_role_text"
+      expect(OM::XML::Terminology.term_generic_name( *[{:conference=>0}, {:role=>1}, :text])).to eq "conference_role_text"
     end
   end
 
   describe "#term_hierarchical_name" do
     it "should generate a specific accessor name based on an array of pointers and indexes" do
-      OM::XML::Terminology.term_hierarchical_name( {:conference=>0}, {:role=>1}, :text ).should == "conference_0_role_1_text"
-      OM::XML::Terminology.term_hierarchical_name( *[{:conference=>0}, {:role=>1}, :text] ).should == "conference_0_role_1_text"
+      expect(OM::XML::Terminology.term_hierarchical_name( {:conference=>0}, {:role=>1}, :text )).to eq "conference_0_role_1_text"
+      expect(OM::XML::Terminology.term_hierarchical_name( *[{:conference=>0}, {:role=>1}, :text] )).to eq "conference_0_role_1_text"
     end
   end
 
   describe ".term_builders" do
     it "should return a hash terms that have been added to the root of the terminology, indexed by term name" do
-      @test_terminology.terms[:name].should == @test_name
+      expect(@test_terminology.terms[:name]).to eq @test_name
     end
   end
 
   describe ".root_terms" do
     it "should return the terms that have been marked root" do
-      @test_full_terminology.root_terms.length.should == 1
-      @test_full_terminology.root_terms.first.should == @test_full_terminology.terms[:mods]
+      expect(@test_full_terminology.root_terms.length).to eq 1
+      expect(@test_full_terminology.root_terms.first).to eq @test_full_terminology.terms[:mods]
     end
   end
 

--- a/spec/unit/validation_spec.rb
+++ b/spec/unit/validation_spec.rb
@@ -19,14 +19,14 @@ describe "OM::XML::Validation" do
 
   describe '#schema_url' do
     it "should allow you to set the schema url" do
-      ValidationTest.schema_url.should == "http://www.loc.gov/standards/mods/v3/mods-3-2.xsd"
+      expect(ValidationTest.schema_url).to eq "http://www.loc.gov/standards/mods/v3/mods-3-2.xsd"
     end
   end
   
   describe "#schema" do
     it "should return an instance of Nokogiri::XML::Schema loaded from the schema url -- fails if no internet connection" do
       skip "no internet connection"
-      ValidationTest.schema.should be_kind_of Nokogiri::XML::Schema
+      expect(ValidationTest.schema).to be_kind_of Nokogiri::XML::Schema
     end
   end
 
@@ -55,11 +55,11 @@ describe "OM::XML::Validation" do
     end
   
     it "should lazy load the schema file from the @schema_url" do
-      ValidationTest.instance_variable_get(:@schema_file).should be_nil
+      expect(ValidationTest.instance_variable_get(:@schema_file)).to be_nil
       ValidationTest.should_receive(:file_from_url).with(ValidationTest.schema_url).once.and_return("fake file")
       ValidationTest.schema_file
-      ValidationTest.instance_variable_get(:@schema_file).should == "fake file"
-      ValidationTest.schema_file.should == "fake file"
+      expect(ValidationTest.instance_variable_get(:@schema_file)).to eq "fake file"
+      expect(ValidationTest.schema_file).to eq "fake file"
     end
   end
 
@@ -69,12 +69,12 @@ describe "OM::XML::Validation" do
       ValidationTest.send(:file_from_url, "http://google.com")
     end
     it "should raise an error if the url is invalid" do
-      lambda {ValidationTest.send(:file_from_url, "")}.should raise_error(RuntimeError, /Could not retrieve file from /)
-      lambda {ValidationTest.send(:file_from_url, "foo")}.should raise_error(RuntimeError, /Could not retrieve file from foo/)
+      expect(lambda {ValidationTest.send(:file_from_url, "")}).to raise_error(RuntimeError, /Could not retrieve file from /)
+      expect(lambda {ValidationTest.send(:file_from_url, "foo")}).to raise_error(RuntimeError, /Could not retrieve file from foo/)
     end
     it "should raise an error if file retrieval fails" do
       skip "no internet connection"
-      lambda {ValidationTest.send(:file_from_url, "http://fedora-commons.org/nonexistent_file")}.should raise_error(RuntimeError, "Could not retrieve file from http://fedora-commons.org/nonexistent_file. Error: 404 Not Found")  
+      expect(lambda {ValidationTest.send(:file_from_url, "http://fedora-commons.org/nonexistent_file")}).to raise_error(RuntimeError, "Could not retrieve file from http://fedora-commons.org/nonexistent_file. Error: 404 Not Found")  
     end
   end
 end

--- a/spec/unit/xml_serialization_spec.rb
+++ b/spec/unit/xml_serialization_spec.rb
@@ -7,8 +7,8 @@ describe "OM::XML::Terminology.to_xml" do
   it "should put terminology details into the xml" do
     expected_xml = "<namespaces>\n  <namespace>\n    <name>oxns</name>\n    <identifier>http://www.loc.gov/mods/v3</identifier>\n  </namespace>\n  <namespace>\n    <name>xmlns:foo</name>\n    <identifier>http://my.custom.namespace</identifier>\n  </namespace>\n  <namespace>\n    <name>xmlns</name>\n    <identifier>http://www.loc.gov/mods/v3</identifier>\n  </namespace>\n</namespaces>"
     xml = @terminology.to_xml
-    xml.xpath("/terminology/schema").to_xml.should == "<schema>http://www.loc.gov/standards/mods/v3/mods-3-2.xsd</schema>"    
-    xml.xpath("/terminology/namespaces").to_xml.should be_equivalent_to expected_xml
+    expect(xml.xpath("/terminology/schema").to_xml).to eq "<schema>http://www.loc.gov/standards/mods/v3/mods-3-2.xsd</schema>"    
+    expect(xml.xpath("/terminology/namespaces").to_xml).to be_equivalent_to expected_xml
   end
   it "should call .to_xml on all of the terms" do
     options = {}
@@ -27,33 +27,33 @@ describe "OM::XML::Term.to_xml" do
   end
   it "should return an xml representation of the Term" do
     xml = @person_first_name.to_xml
-    xml.xpath("/term").first.attributes["name"].value.should == "first_name"
-    xml.xpath("/term/attributes/type").first.text.should == "given"
-    xml.xpath("/term/path").first.text.should == "namePart"
-    xml.xpath("/term/namespace_prefix").first.text.should == "oxns"
-    xml.xpath("/term/children/*").should be_empty
-    xml.xpath("/term/xpath/relative").first.text.should == "oxns:namePart[@type=\"given\"]"
-    xml.xpath("/term/xpath/absolute").first.text.should == "//oxns:name[@type=\"personal\"]/oxns:namePart[@type=\"given\"]"
-    xml.xpath("/term/xpath/constrained").first.text.should == "//oxns:name[@type=\\\"personal\\\"]/oxns:namePart[@type=\\\"given\\\" and contains(., \\\"\#{constraint_value}\\\")]"
-    xml.xpath("/term/index_as").first.text.should == ""
-    xml.xpath("/term/required").first.text.should == "false"
-    xml.xpath("/term/data_type").first.text.should == "string"
+    expect(xml.xpath("/term").first.attributes["name"].value).to eq "first_name"
+    expect(xml.xpath("/term/attributes/type").first.text).to eq "given"
+    expect(xml.xpath("/term/path").first.text).to eq "namePart"
+    expect(xml.xpath("/term/namespace_prefix").first.text).to eq "oxns"
+    expect(xml.xpath("/term/children/*")).to be_empty
+    expect(xml.xpath("/term/xpath/relative").first.text).to eq "oxns:namePart[@type=\"given\"]"
+    expect(xml.xpath("/term/xpath/absolute").first.text).to eq "//oxns:name[@type=\"personal\"]/oxns:namePart[@type=\"given\"]"
+    expect(xml.xpath("/term/xpath/constrained").first.text).to eq "//oxns:name[@type=\\\"personal\\\"]/oxns:namePart[@type=\\\"given\\\" and contains(., \\\"\#{constraint_value}\\\")]"
+    expect(xml.xpath("/term/index_as").first.text).to eq ""
+    expect(xml.xpath("/term/required").first.text).to eq "false"
+    expect(xml.xpath("/term/data_type").first.text).to eq "string"
   end
   it "should capture root term info" do
     xml = @terminology.root_terms.first.to_xml
     xml.xpath("/term/is_root_term").text.should == "true"
-    @person_first_name.to_xml.xpath("/term/is_root_term").should be_empty
+    expect(@person_first_name.to_xml.xpath("/term/is_root_term")).to be_empty
   end
   it "should allow you to pass in a document to add the term to" do
     doc = Nokogiri::XML::Document.new
-    @person_first_name.to_xml({}, doc).should == doc
+    expect(@person_first_name.to_xml({}, doc)).to eq doc
   end
   it "should include children" do
     children = @person.to_xml.xpath("//term[@name=\"person\"]/children/*")
     children.length.should == 12
-    children.each {|child| child.name.should == "term"}
+    children.each {|child| expect(child.name).to eq "term"}
   end
   it "should skip children if :children=>false" do
-    @person.to_xml(:children=>false).xpath("children").should be_empty
+    expect(@person.to_xml(:children=>false).xpath("children")).to be_empty
   end
 end

--- a/spec/unit/xml_spec.rb
+++ b/spec/unit/xml_spec.rb
@@ -9,13 +9,13 @@ describe "OM::XML::Container" do
   end
   
   it "should automatically include the other modules" do
-    XMLTest.included_modules.should include(OM::XML::Container)
-    XMLTest.included_modules.should include(OM::XML::Validation)
+    expect(XMLTest.included_modules).to include(OM::XML::Container)
+    expect(XMLTest.included_modules).to include(OM::XML::Validation)
   end
   
   describe "#sanitize_pointer" do
     it "should convert any nested arrays into hashes" do
-      XMLTest.sanitize_pointer( [[:person,1],:role] ).should == [{:person=>1},:role]
+      expect(XMLTest.sanitize_pointer( [[:person,1],:role] )).to eq [{:person=>1},:role]
     end
   end
   

--- a/spec/unit/xml_terminology_based_solrizer_spec.rb
+++ b/spec/unit/xml_terminology_based_solrizer_spec.rb
@@ -16,13 +16,13 @@ describe OM::XML::TerminologyBasedSolrizer do
   describe ".to_solr" do
   
     it "should provide .to_solr and return a SolrDocument" do
-      @mods_article.should respond_to(:to_solr)
-      @mods_article.to_solr.should be_kind_of(Hash)
+      expect(@mods_article).to respond_to(:to_solr)
+      expect(@mods_article.to_solr).to be_kind_of(Hash)
     end
   
     it "should optionally allow you to provide the Hash to add fields to and return that document when done" do
       doc = Hash.new
-      @mods_article.to_solr(doc).should equal(doc)
+      expect(@mods_article.to_solr(doc)).to equal(doc)
     end
   
     it "should iterate through the terminology terms, calling .solrize_term on each and passing in the solr doc" do
@@ -37,17 +37,17 @@ describe OM::XML::TerminologyBasedSolrizer do
   
     it "should use Solr mappings to generate field names" do
       solr_doc =  @mods_article.to_solr
-      solr_doc["abstract"].should be_nil
+      expect(solr_doc["abstract"]).to be_nil
       # NOTE:  OM's old default expected stored and indexed;  this is a change.
-      solr_doc["abstract_tesim"].should == ["ABSTRACT"]
-      solr_doc["title_info_1_language_tesim"].should == ["finnish"]
-      solr_doc["person_1_role_0_text_tesim"].should == ["teacher"]
+      expect(solr_doc["abstract_tesim"]).to eq ["ABSTRACT"]
+      expect(solr_doc["title_info_1_language_tesim"]).to eq ["finnish"]
+      expect(solr_doc["person_1_role_0_text_tesim"]).to eq ["teacher"]
       # No index_as on the code field.
-      solr_doc["person_1_role_0_code_tesim"].should be_nil 
-      solr_doc["person_last_name_tesim"].sort.should == ["FAMILY NAME", "Gautama"]
-      solr_doc["topic_tag_tesim"].sort.should == ["CONTROLLED TERM", "TOPIC 1", "TOPIC 2"]
+      expect(solr_doc["person_1_role_0_code_tesim"]).to be_nil 
+      expect(solr_doc["person_last_name_tesim"].sort).to eq ["FAMILY NAME", "Gautama"]
+      expect(solr_doc["topic_tag_tesim"].sort).to eq ["CONTROLLED TERM", "TOPIC 1", "TOPIC 2"]
       # These are a holdover from an old verison of OM
-      solr_doc['journal_0_issue_0_publication_date_dtsim'].should == ["2007-02-01T00:00:00Z"]
+      expect(solr_doc['journal_0_issue_0_publication_date_dtsim']).to eq ["2007-02-01T00:00:00Z"]
     end
 
   end
@@ -57,7 +57,7 @@ describe OM::XML::TerminologyBasedSolrizer do
     it "should add fields to a solr document for all nodes corresponding to the given term and its children" do
       solr_doc = Hash.new
       result = @mods_article.solrize_term(Samples::ModsArticle.terminology.retrieve_term(:title_info), solr_doc)
-      result.should == solr_doc
+      expect(result).to be solr_doc
     end
 
     it "should add multiple fields based on index_as" do
@@ -70,7 +70,7 @@ describe OM::XML::TerminologyBasedSolrizer do
       expected_names = ["DR.", "FAMILY NAME", "GIVEN NAMES", "PERSON_ID"]
       %w(_teim _sim).each do |suffix|
         actual_names = fake_solr_doc["name_0_namePart#{suffix}"].sort
-        actual_names.should == expected_names
+        expect(actual_names).to eq expected_names
       end
     end
 
@@ -78,14 +78,14 @@ describe OM::XML::TerminologyBasedSolrizer do
       unless RUBY_VERSION.match("1.8.7")
         solr_doc = Hash.new
         result = @mods_article.solrize_term(Samples::ModsArticle.terminology.retrieve_term(:pub_date), solr_doc)
-        solr_doc["pub_date_dtsim"].should == ["2007-02-01T00:00:00Z"]
+        expect(solr_doc["pub_date_dtsim"]).to eq ["2007-02-01T00:00:00Z"]
       end
     end
 
     it "should add fields based on type using ref" do
       solr_doc = Hash.new
       result = @mods_article.solrize_term(Samples::ModsArticle.terminology.retrieve_term(:issue_date), solr_doc)
-      solr_doc["issue_date_dtsim"].should == ["2007-02-15T00:00:00Z"]
+      expect(solr_doc["issue_date_dtsim"]).to eq ["2007-02-15T00:00:00Z"]
     end
 
     it "shouldn't index terms where index_as is an empty array" do
@@ -94,7 +94,7 @@ describe OM::XML::TerminologyBasedSolrizer do
       term.children[:namePart].index_as = []
 
       @mods_article.solrize_term(term, fake_solr_doc)
-      fake_solr_doc["name_0_namePart_teim"].should be_nil
+      expect(fake_solr_doc["name_0_namePart_teim"]).to be_nil
     end
 
     it "should index terms where index_as is searchable" do
@@ -104,7 +104,7 @@ describe OM::XML::TerminologyBasedSolrizer do
 
       @mods_article.solrize_term(term, fake_solr_doc)
       
-      fake_solr_doc["name_0_namePart_teim"].sort.should == ["DR.", "FAMILY NAME", "GIVEN NAMES", "PERSON_ID"]
+      expect(fake_solr_doc["name_0_namePart_teim"].sort).to eq ["DR.", "FAMILY NAME", "GIVEN NAMES", "PERSON_ID"]
     end
   end
 end


### PR DESCRIPTION
Hullo!

I saw https://github.com/projecthydra/om/issues/48 and figured I'd take a pass at changing the test suite
away from `object.should()` to the newer, preferred `expect(_object_).to(_matcher_)`.

Also - this is my first contribution so I've filed my iCLA this morning and tried my best to adhere to your [guidelines for contributing](https://github.com/projecthydra/om/blob/master/CONTRIBUTING.md).

