### PR TITLE
Convert specs to RSpec 2.99.2 syntax with Transpec

### DIFF
--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe "OM::XML::Container" do
-  
+
   before(:all) do
     class ContainerTest
       include OM::XML::Container
     end
   end
-  
+
   subject {
     ContainerTest.from_xml("<foo><bar>1</bar></foo>")
   }
@@ -20,7 +20,7 @@ describe "OM::XML::Container" do
   it "should initialize" do
     expect(ContainerTest.new.ng_xml).to be_a_kind_of Nokogiri::XML::Document
   end
-  
+
   describe "new" do
     it "should populate ng_xml with an instance of Nokogiri::XML::Document" do
       expect(subject.ng_xml.class).to eq Nokogiri::XML::Document
@@ -29,13 +29,13 @@ describe "OM::XML::Container" do
 
   describe "#from_xml" do
     it "should accept a String, parse it and store it in .ng_xml" do
-      Nokogiri::XML::Document.should_receive(:parse).and_return("parsed xml")
+      expect(Nokogiri::XML::Document).to receive(:parse).and_return("parsed xml")
       container1 = ContainerTest.from_xml("<foo><bar>1</bar></foo>")
       expect(container1.ng_xml).to eq "parsed xml"
     end
     it "should accept a File, parse it and store it in .ng_xml" do
       file = fixture(File.join("mods_articles", "hydrangea_article1.xml"))
-      Nokogiri::XML::Document.should_receive(:parse).and_return("parsed xml")
+      expect(Nokogiri::XML::Document).to receive(:parse).and_return("parsed xml")
       container1 = ContainerTest.from_xml(file)
       expect(container1.ng_xml).to eq "parsed xml"
     end
@@ -45,36 +45,36 @@ describe "OM::XML::Container" do
       expect(container1.ng_xml).to eq parsed_xml
     end
   end
-  
+
   describe ".to_xml" do
     it  "should call .ng_xml.to_xml" do
-      subject.ng_xml.should_receive(:to_xml).and_return("ng xml")
-      subject.to_xml.should == "ng xml"
+      expect(subject.ng_xml).to receive(:to_xml).and_return("ng xml")
+      expect(subject.to_xml).to eq("ng xml")
     end
-    
+
     it 'should accept an optional Nokogiri::XML Document as an argument and insert its fields into that (mocked test)' do
       doc = Nokogiri::XML::Document.parse("<test_xml/>")
       mock_new_node = double("new node")
-      doc.root.should_receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
+      expect(doc.root).to receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
       result = subject.to_xml(doc)
     end
-    
+
     it 'should accept an optional Nokogiri::XML Document as an argument and insert its fields into that (functional test)' do
       doc = Nokogiri::XML::Document.parse("<test_xml/>")
       expect(subject.to_xml(doc)).to eq "<?xml version=\"1.0\"?>\n<test_xml>\n  <foo>\n    <bar>1</bar>\n  </foo>\n</test_xml>\n"
     end
-    
+
     it 'should add to root of Nokogiri::XML::Documents, but add directly to the elements if a Nokogiri::XML::Node is passed in' do
       mock_new_node = double("new node")
-      mock_new_node.stub(:to_xml).and_return("foo")
-      
+      allow(mock_new_node).to receive(:to_xml).and_return("foo")
       doc = Nokogiri::XML::Document.parse("<test_document/>")
       el = Nokogiri::XML::Node.new("test_element", Nokogiri::XML::Document.new)
-      doc.root.should_receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
-      el.should_receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
-      subject.to_xml(doc).should
-      subject.to_xml(el)
+      skip "Test not fully implemented"
+      expect(doc.root).to receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
+      expect(el).to receive(:add_child).with(subject.ng_xml.root).and_return(mock_new_node)
+      # expect(subject.to_xml(doc)).to be_equivalent_to
+      # expect(subject.to_xml(el )).to be_equivalent_to
     end
   end
-  
+
 end

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -97,18 +97,18 @@ describe "OM::XML::Document" do
     end
 
     it "should allow you to search by term pointer" do
-      @fixturemods.ng_xml.should_receive(:xpath).with('//oxns:name[@type="personal"]', @fixturemods.ox_namespaces)
+      expect(@fixturemods.ng_xml).to receive(:xpath).with('//oxns:name[@type="personal"]', @fixturemods.ox_namespaces)
       @fixturemods.find_by_terms_and_value(:person)
     end
     it "should allow you to constrain your searches" do
-      @fixturemods.ng_xml.should_receive(:xpath).with('//oxns:name[@type="personal" and contains(., "Beethoven, Ludwig van")]', @fixturemods.ox_namespaces)
+      expect(@fixturemods.ng_xml).to receive(:xpath).with('//oxns:name[@type="personal" and contains(., "Beethoven, Ludwig van")]', @fixturemods.ox_namespaces)
       @fixturemods.find_by_terms_and_value(:person, "Beethoven, Ludwig van")
     end
     it "should allow you to use complex constraints" do
-      @fixturemods.ng_xml.should_receive(:xpath).with('//oxns:name[@type="personal"]/oxns:namePart[@type="date" and contains(., "2010")]', @fixturemods.ox_namespaces)
+      expect(@fixturemods.ng_xml).to receive(:xpath).with('//oxns:name[@type="personal"]/oxns:namePart[@type="date" and contains(., "2010")]', @fixturemods.ox_namespaces)
       @fixturemods.find_by_terms_and_value(:person, :date=>"2010")
       
-      @fixturemods.ng_xml.should_receive(:xpath).with('//oxns:name[@type="personal"]/oxns:role[contains(., "donor")]', @fixturemods.ox_namespaces)
+      expect(@fixturemods.ng_xml).to receive(:xpath).with('//oxns:name[@type="personal"]/oxns:role[contains(., "donor")]', @fixturemods.ox_namespaces)
       @fixturemods.find_by_terms_and_value(:person, :role=>"donor")
     end
   end

--- a/spec/unit/dynamic_node_spec.rb
+++ b/spec/unit/dynamic_node_spec.rb
@@ -125,7 +125,7 @@ describe "OM::XML::DynamicNode" do
       end
 
       it "Should work with proxies" do
-        @article.title.should == ["ARTICLE TITLE HYDRANGEA ARTICLE 1", "Artikkelin otsikko Hydrangea artiklan 1", "TITLE OF HOST JOURNAL"]
+        expect(@article.title).to eq(["ARTICLE TITLE HYDRANGEA ARTICLE 1", "Artikkelin otsikko Hydrangea artiklan 1", "TITLE OF HOST JOURNAL"])
         expect(@article.title.main_title_lang).to eq ['eng']
 
         expect(@article.title(1).to_pointer).to eq [{:title => 1}]
@@ -152,7 +152,7 @@ describe "OM::XML::DynamicNode" do
         it "should return a Nokogiri NodeSet" do
           @article.update_values( {[{:journal=>0}, {:issue=>3}, :pages, :start]=>"434" })
           nodeset = @article.journal(0).issue(1).pages.start.nodeset
-          nodeset.should be_kind_of Nokogiri::XML::NodeSet
+          expect(nodeset).to be_kind_of Nokogiri::XML::NodeSet
           expect(nodeset.length).to eq @article.journal(0).issue(1).pages.start.length
           expect(nodeset.first.text).to eq @article.journal(0).issue(1).pages.start.first
         end

--- a/spec/unit/named_term_proxy_spec.rb
+++ b/spec/unit/named_term_proxy_spec.rb
@@ -31,13 +31,13 @@ describe "OM::XML::NamedTermProxy" do
     
   it "should proxy all extra methods to the proxied object" do
     [:xpath, :xpath_relative, :xml_builder_template].each do |method|
-      @proxied_term.should_receive(method)
+      expect(@proxied_term).to receive(method)
       @test_proxy.send(method)
     end
   end
 
   it "should proxy the term specified by the builder" do
-    @test_proxy.proxied_term.should == @test_terminology.retrieve_term(:parent, :foo, :bar)
+    expect(@test_proxy.proxied_term).to eq(@test_terminology.retrieve_term(:parent, :foo, :bar))
     expect(@test_proxy.xpath).to eq "//oxns:parent/oxns:foo/oxns:bar"
   end
 
@@ -48,7 +48,7 @@ describe "OM::XML::NamedTermProxy" do
   end
 
   it "should support NamedTermProxies that point to root terms" do
-    @test_terminology.xpath_for(:parentfoobarproxy).should == "//oxns:parent/oxns:foo/oxns:bar"
+    expect(@test_terminology.xpath_for(:parentfoobarproxy)).to eq("//oxns:parent/oxns:foo/oxns:bar")
   end
 
   it "should be usable in update_values" do

--- a/spec/unit/template_registry_spec.rb
+++ b/spec/unit/template_registry_spec.rb
@@ -43,33 +43,33 @@ describe "OM::XML::TemplateRegistry" do
     end
 
     it "should define new templates" do
-      RegistryTest.template_registry.node_types.should_not include(:zombie)
+      expect(RegistryTest.template_registry.node_types).not_to include(:zombie)
       RegistryTest.define_template :zombie do |xml,name|
         xml.monster(:wants => 'braaaaainz') do
           xml.text(name)
         end
       end
-      RegistryTest.template_registry.node_types.should include(:zombie)
+      expect(RegistryTest.template_registry.node_types).to include(:zombie)
     end
 
     it "should instantiate a detached node from a template" do
       node = RegistryTest.template_registry.instantiate(:zombie, 'Zeke')
       expectation = Nokogiri::XML('<monster wants="braaaaainz">Zeke</monster>').root
-      node.should be_equivalent_to(expectation)
+      expect(node).to be_equivalent_to(expectation)
     end
     
     it "should raise an error when trying to instantiate an unknown node_type" do
-      lambda { RegistryTest.template_registry.instantiate(:demigod, 'Hercules') }.should raise_error(NameError)
+      expect { RegistryTest.template_registry.instantiate(:demigod, 'Hercules') }.to raise_error(NameError)
     end
     
     it "should raise an exception if a missing method name doesn't match a node_type" do
-      lambda { RegistryTest.template_registry.demigod('Hercules') }.should raise_error(NameError)
+      expect { RegistryTest.template_registry.demigod('Hercules') }.to raise_error(NameError)
     end
     
     it "should undefine existing templates" do
-      RegistryTest.template_registry.node_types.should include(:zombie)
+      expect(RegistryTest.template_registry.node_types).to include(:zombie)
       RegistryTest.template_registry.undefine :zombie
-      RegistryTest.template_registry.node_types.should_not include(:zombie)
+      expect(RegistryTest.template_registry.node_types).not_to include(:zombie)
     end
     
     it "should complain if the template name isn't a symbol" do
@@ -117,26 +117,26 @@ describe "OM::XML::TemplateRegistry" do
 
     it "should add_previous_sibling" do
       return_value = @test_document.template_registry.add_previous_sibling(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 0).first
+      expect(return_value).to eq(@test_document.find_by_terms(:person => 0).first)
       expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:before]).respecting_element_order
     end
 
     it "should after" do
       return_value = @test_document.template_registry.after(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 0).first
+      expect(return_value).to eq(@test_document.find_by_terms(:person => 0).first)
       expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:after]).respecting_element_order
     end
 
     it "should before" do
       return_value = @test_document.template_registry.before(@test_document.find_by_terms(:person => 0), :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 1).first
+      expect(return_value).to eq(@test_document.find_by_terms(:person => 1).first)
       expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:before]).respecting_element_order
     end
 
     it "should replace" do
       target_node = @test_document.find_by_terms(:person => 0).first
       return_value = @test_document.template_registry.replace(target_node, :person, 'Bob', 'Builder')
-      return_value.should == @test_document.find_by_terms(:person => 0).first
+      expect(return_value).to eq(@test_document.find_by_terms(:person => 0).first)
       expect(@test_document.ng_xml).to be_equivalent_to(@expectations[:instead]).respecting_element_order
     end
 
@@ -150,10 +150,10 @@ describe "OM::XML::TemplateRegistry" do
     it "should yield the result if a block is given" do
       target_node = @test_document.find_by_terms(:person => 0).first
       expectation = Nokogiri::XML('<person xmlns="urn:registry-test" title="Actor">Alice</person>').root
-      @test_document.template_registry.swap(target_node, :person, 'Bob', 'Builder') { |old_node|
+      expect(@test_document.template_registry.swap(target_node, :person, 'Bob', 'Builder') { |old_node|
         expect(old_node).to be_equivalent_to(expectation)
         old_node
-      }.should be_equivalent_to(expectation)
+      }).to be_equivalent_to(expectation)
     end
   end
     

--- a/spec/unit/term_builder_spec.rb
+++ b/spec/unit/term_builder_spec.rb
@@ -109,21 +109,21 @@ describe "OM::XML::Term::Builder" do
         t.proxy = [:foo, :bar]
       end
       result = test_builder.build
-      result.should be_kind_of OM::XML::NamedTermProxy
+      expect(result).to be_kind_of OM::XML::NamedTermProxy
     end
     it "should set path to match name if it is empty" do
       expect(@test_builder.settings[:path]).to be_nil
       expect(@test_builder.build.path).to eq @test_builder.name.to_s
     end
     it "should work recursively, calling .build on any of its children" do
-      OM::XML::Term.any_instance.stub(:generate_xpath_queries!)
+      allow_any_instance_of(OM::XML::Term).to receive(:generate_xpath_queries!)
       built_child1 = OM::XML::Term.new("child1")
       built_child2 = OM::XML::Term.new("child2")
 
       mock1 = double("Builder1", :build => built_child1 )
       mock2 = double("Builder2", :build => built_child2 )
-      mock1.stub(:name).and_return("child1")
-      mock2.stub(:name).and_return("child2")
+      allow(mock1).to receive(:name).and_return("child1")
+      allow(mock2).to receive(:name).and_return("child2")
 
       @test_builder.children = {:mock1=>mock1, :mock2=>mock2}
       result = @test_builder.build
@@ -156,10 +156,10 @@ describe "OM::XML::Term::Builder" do
       tb = OM::XML::Term::Builder.new("mork",@test_terminology_builder).tap do |t|
         t.ref = [:characters, :aliens]
       end
-      lambda { tb.lookup_refs }.should raise_error(OM::XML::Terminology::BadPointerError,"This TerminologyBuilder does not have a root TermBuilder defined that corresponds to \":characters\"")
+      expect { tb.lookup_refs }.to raise_error(OM::XML::Terminology::BadPointerError,"This TerminologyBuilder does not have a root TermBuilder defined that corresponds to \":characters\"")
     end
     it "should raise an error with informative error when given circular references" do
-      lambda { @pineapple.lookup_refs }.should raise_error(OM::XML::Terminology::CircularReferenceError,"Circular reference in Terminology: :pineapple => :banana => :coconut => :pineapple")
+      expect { @pineapple.lookup_refs }.to raise_error(OM::XML::Terminology::CircularReferenceError,"Circular reference in Terminology: :pineapple => :banana => :coconut => :pineapple")
     end
   end
   

--- a/spec/unit/term_spec.rb
+++ b/spec/unit/term_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe OM::XML::Term do
   describe "without a type" do
     it "should default to string" do
-      OM::XML::Term.new(:test_term).type.should == :string
+      expect(OM::XML::Term.new(:test_term).type).to eq(:string)
     end
   end
   describe "when type is specified" do
@@ -79,7 +79,7 @@ describe OM::XML::Term do
       it "should crawl down into mapper children to find the desired term" do
         mock_role = double("mapper", :children =>{:text=>"the target"})
         mock_conference = double("mapper", :children =>{:role=>mock_role})
-        @test_name_part.should_receive(:children).and_return({:conference=>mock_conference})
+        expect(@test_name_part).to receive(:children).and_return({:conference=>mock_conference})
         expect(@test_name_part.retrieve_term(:conference, :role, :text)).to eq "the target"
       end
       it "should return an empty hash if no term can be found" do
@@ -188,8 +188,8 @@ describe OM::XML::Term do
       end
       it "should trigger update on any child objects" do
         mock_child = double("child term")
-        mock_child.should_receive(:generate_xpath_queries!).exactly(3).times
-        @test_name_part.should_receive(:children).and_return({1=>mock_child, 2=>mock_child, 3=>mock_child})
+        expect(mock_child).to receive(:generate_xpath_queries!).exactly(3).times
+        expect(@test_name_part).to receive(:children).and_return({1=>mock_child, 2=>mock_child, 3=>mock_child})
         @test_name_part.generate_xpath_queries!
       end
     end

--- a/spec/unit/term_value_operators_spec.rb
+++ b/spec/unit/term_value_operators_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe "OM::XML::TermValueOperators" do
-  
+
   before(:each) do
     @sample = OM::Samples::ModsArticle.from_xml( fixture( File.join("test_dummy_mods.xml") ) )
     @article = OM::Samples::ModsArticle.from_xml( fixture( File.join("mods_articles","hydrangea_article1.xml") ) )
     @empty_sample = OM::Samples::ModsArticle.from_xml("")
   end
-  
+
   describe ".term_values" do
 
     it "should return build an array of values from the nodeset corresponding to the given term" do
@@ -25,10 +25,10 @@ describe "OM::XML::TermValueOperators" do
     it "should ignore whitespace elements for a term pointing to a text() node for an element that contains children" do
       expect(@article.term_values(:name, :name_content)).to eq ["Describes a person"]
     end
-  
+
   end
-  
-  
+
+
   describe ".update_values" do
     it "should update the xml according to the find_by_terms_and_values in the given hash" do
       terms_attributes = {[{":person"=>"0"}, "affiliation"]=>{'1' => "affiliation1", '2'=> "affiliation2", '3' => "affiliation3"}, [{:person=>1}, :last_name]=>"Andronicus", [{"person"=>"1"},:first_name]=>["Titus"],[{:person=>1},:role]=>["otherrole1","otherrole2"] }
@@ -38,14 +38,14 @@ describe "OM::XML::TermValueOperators" do
       expect(person_0_affiliation[0].text).to eq "affiliation1"
       expect(person_0_affiliation[1].text).to eq "affiliation2"
       expect(person_0_affiliation[2].text).to eq "affiliation3"
-      
+
       person_1_last_names = @article.find_by_terms({:person=>1}, :last_name)
       expect(person_1_last_names.length).to eq 1
       expect(person_1_last_names.first.text).to eq "Andronicus"
-      
+
       person_1_first_names = @article.find_by_terms({:person=>1}, :first_name)
       expect(person_1_first_names.first.text).to eq "Titus"
-      
+
       person_1_roles = @article.find_by_terms({:person=>1}, :role)
       expect(person_1_roles[0].text).to eq "otherrole1"
       expect(person_1_roles[1].text).to eq "otherrole2"
@@ -57,10 +57,10 @@ describe "OM::XML::TermValueOperators" do
     end
 
     it "should call term_value_update if the corresponding node already exists" do
-      @article.should_receive(:term_value_update).with('//oxns:titleInfo/oxns:title', 0, "My New Title")
+      expect(@article).to receive(:term_value_update).with('//oxns:titleInfo/oxns:title', 0, "My New Title")
       @article.update_values( {[:title_info, :main_title] => "My New Title"} )
     end
-    
+
     it "should call term_values_append if the corresponding node does not already exist or if the requested index is -1" do
       expected_args = {
         # :parent_select => OM::Samples::ModsArticle.terminology.xpath_with_indexes(*[{:person=>0}]) ,
@@ -69,18 +69,18 @@ describe "OM::XML::TermValueOperators" do
         :template => [:person, :role],
         :values => "My New Role"
       }
-      @article.should_receive(:term_values_append).with(expected_args).twice
+      expect(@article).to receive(:term_values_append).with(expected_args).twice
       @article.update_values( {[{:person=>0}, {:role => 6}] => "My New Role"} )
       @article.update_values( {[{:person=>0}, {:role => 7}] => "My New Role"} )
     end
-    
+
     it "should support updating attribute values" do
       pointer = [:title_info, :language]
       test_val = "language value"
       @article.update_values( {pointer=>test_val} )
       expect(@article.term_values(*pointer).first).to eq test_val
     end
-    
+
     it "should not get tripped up on root nodes" do
       @article.update_values([:title_info]=>["york", "mangle","mork"])
       expect(@article.term_values(*[:title_info])).to eq ["york", "mangle", "mork"]
@@ -98,22 +98,22 @@ describe "OM::XML::TermValueOperators" do
       @article.update_values( { [{:person=>0}, :role]=>["one", "two"] })
       expect(@article.term_values( {:person=>0}, :role)).to eq ["one", "two"]
     end
-    
+
     it "should traverse named term proxies transparently" do
-      expect(@article.term_values( :journal, :issue, :start_page)).not_to eq ["108"]      
+      expect(@article.term_values( :journal, :issue, :start_page)).not_to eq ["108"]
       @article.update_values( { ["journal", "issue", "start_page"]=>"108" } )
-      expect(@article.term_values( :journal, :issue, :start_page)).to eq ["108"]      
+      expect(@article.term_values( :journal, :issue, :start_page)).to eq ["108"]
       expect(@article.term_values( :journal, :issue, :pages, :start)).to eq ["108"]
     end
-    
+
     it "should create the necessary ancestor nodes when necessary" do
-  	  @sample.find_by_terms(:person).length.should == 4
-  	  @sample.update_values([{:person=>8}, :role, :text]=>"my role")
+      expect(@sample.find_by_terms(:person).length).to eq(4)
+      @sample.update_values([{:person=>8}, :role, :text]=>"my role")
       person_entries = @sample.find_by_terms(:person)
       expect(person_entries.length).to eq 5
-      expect(person_entries[4].search("./ns3:role").first.text).to eq "my role" 
-	  end
-	  
+      expect(person_entries[4].search("./ns3:role").first.text).to eq "my role"
+    end
+
     it "should create deep trees of ancestor nodes" do
       result = @article.update_values( {[{:journal=>0}, {:issue=>3}, :pages, :start]=>"434" })
       expect(@article.find_by_terms({:journal=>0}, :issue).length).to eq 2
@@ -123,15 +123,15 @@ describe "OM::XML::TermValueOperators" do
       #Last argument is a filter, we must explicitly pass no filter
       expect(@article.class.terminology.xpath_with_indexes(:subject, {:topic=>1}, {})).to eq '//oxns:subject/oxns:topic[2]'
       expect(@article.find_by_terms(:subject, {:topic => 1}, {}).text).to eq "TOPIC 2"
-	  end
-	  
-	  it "should accommodate appending term values with apostrophes in them"  do
-	    expect(@article.find_by_terms(:person, :description)).to be_empty  # making sure that there's no description node -- forces a value_append
+    end
+
+    it "should accommodate appending term values with apostrophes in them"  do
+      expect(@article.find_by_terms(:person, :description)).to be_empty  # making sure that there's no description node -- forces a value_append
       terms_update_hash =  {[:person, :description]=>" 'phrul gyi lde mig"}
       result = @article.update_values(terms_update_hash)
       expect(@article.term_values(:person, :description)).to include(" 'phrul gyi lde mig")
     end
-    
+
     it "should support inserting nodes with namespaced attributes" do
       @sample.update_values({['title_info', 'french_title']=>'Le Titre'})
       expect(@sample.term_values('title_info', 'french_title')).to eq ['Le Titre']
@@ -142,7 +142,7 @@ describe "OM::XML::TermValueOperators" do
       @sample.update_values({['title_info', 'language']=>'Le Titre'})
       expect(@sample.term_values('title_info', 'french_title')).to eq ['Le Titre']
     end
-    
+
     it "should support inserting namespaced attributes" do
       skip "HYDRA-415"
       @sample.update_values({['title_info', 'main_title', 'main_title_lang']=>'eng'})
@@ -150,9 +150,9 @@ describe "OM::XML::TermValueOperators" do
       ## After a proxy
       expect(@article.term_values(:title,:main_title_lang)).to eq ['eng']
     end
-    
+
     ### Examples copied over form nokogiri_datastream_spec
-    
+
     it "should apply submitted hash to corresponding datastream field values" do
       result = @article.update_values( {[{":person"=>"0"}, "first_name"]=>["Billy", "Bob", "Joe"] })
       expect(result).to eq({"person_0_first_name"=>["Billy", "Bob", "Joe"]})
@@ -165,7 +165,7 @@ describe "OM::XML::TermValueOperators" do
       # In other words, { [:journal, :title_info]=>"dork" } should have the same effect as { [:journal, :title_info]=>{"0"=>"dork"} }
       result = @article.update_values( { [{":person"=>"0"}, "role"]=>"the role" } )
       expect(result).to eq({"person_0_role"=>["the role"]})
-      expect(@article.term_values({:person=>0}, :role).first).to eq "the role"     
+      expect(@article.term_values({:person=>0}, :role).first).to eq "the role"
       expect(@article.term_values('//oxns:name[@type="personal"][1]/oxns:role').first).to eq "the role"
     end
     it "should do nothing if field key is a string (must be an array or symbol).  Will not accept xpath queries!" do
@@ -178,8 +178,8 @@ describe "OM::XML::TermValueOperators" do
       expect(@article.update_values( { [{"fubar"=>"0"}]=>"the role" } )).to eq({})
       expect(@article.to_xml).to eq xml_before
     end
-    
-    it "should work for text fields" do 
+
+    it "should work for text fields" do
       att= {[{"person"=>"0"},"description"]=>["mork", "york"]}
       result = @article.update_values(att)
       expect(result).to eq({"person_0_description"=>["mork", "york"]})
@@ -189,7 +189,7 @@ describe "OM::XML::TermValueOperators" do
       expect(result2).to eq({"person_0_description_2"=>["dork"]})
       expect(@article.term_values({:person=>0},:description)).to eq ['mork', 'york', 'dork']
     end
-    
+
     it "should append nodes at the specified index if possible" do
       @article.update_values([:journal, :title_info]=>["all", "for", "the"])
       att = {[:journal, {:title_info => 3}]=>'glory'}
@@ -203,7 +203,7 @@ describe "OM::XML::TermValueOperators" do
       result = @article.update_values({[:journal, :title_info]=>["six", "seven"]})
       expect((@article.term_values(:journal, :title_info))).to eq ["six", "seven"]
     end
-    
+
     it "should append values to the end of the array if the specified index is higher than the length of the values array" do
       att = {[:journal, :issue, :pages, {:end => 3}]=>'108'}
       expect(@article.term_values(:journal, :issue, :pages, :end)).to eq []
@@ -211,15 +211,15 @@ describe "OM::XML::TermValueOperators" do
       expect(result).to eq({"journal_issue_pages_end_3"=>["108"]})
       expect(@article.term_values(:journal, :issue, :pages, :end)).to eq ["108"]
     end
-    
+
     it "should allow deleting of values and should delete values so that to_xml does not return emtpy nodes" do
       att= {[:journal, :title_info]=>["york", "mangle","mork"]}
       @article.update_values(att)
       expect(@article.term_values(:journal, :title_info)).to eq ['york', 'mangle', 'mork']
-      
+
       @article.update_values({[:journal, {:title_info => 1}]=>nil})
       expect(@article.term_values(:journal, :title_info)).to eq ['york', 'mork']
-      
+
       @article.update_values({[:journal, {:title_info => 0}]=>:delete})
       expect(@article.term_values(:journal, :title_info)).to eq ['mork']
     end
@@ -238,7 +238,7 @@ describe "OM::XML::TermValueOperators" do
       end
 
       it "if delete_on_update? returns false, setting to nil won't delete node" do
-        @article.stub('delete_on_update?').and_return(false)
+        allow(@article).to receive('delete_on_update?').and_return(false)
         @article.update_values({[:journal, {:title_info => 1}]=>""})
         expect(@article.term_values(:journal, :title_info)).to eq ['york', '', 'mork']
       end
@@ -251,23 +251,12 @@ describe "OM::XML::TermValueOperators" do
       expect(@article.term_values(:name,:name_content)).to eq ["Test text"]
       expect(@article.find_by_terms(:name).children.length()).to eq 35
     end
-    
+
   end
-  
+
   describe ".term_values_append" do
-	
-  	it "looks up the parent using :parent_select, uses :parent_index to choose the parent node from the result set, uses :template to build the node(s) to be inserted, inserts the :values(s) into the node(s) and adds the node(s) to the parent" do      
-	    @sample.term_values_append(
-        :parent_select => [:person, {:first_name=>"Tim", :last_name=>"Berners-Lee"}] ,
-        :parent_index => :first,
-        :template => [:person, :affiliation],
-        :values => ["my new value", "another new value"] 
-      )
-    end
-    
-    it "should accept parent_select and template [term_reference, find_by_terms_and_value_opts] as argument arrays for generators/find_by_terms_and_values" do
-      # this appends two affiliation nodes into the first person node whose name is Tim Berners-Lee
-      expected_result = '<ns3:name type="personal">
+    before :each do
+      @expected_result = '<ns3:name type="personal">
       <ns3:namePart type="family">Berners-Lee</ns3:namePart>
       <ns3:namePart type="given">Tim</ns3:namePart>
       <ns3:role>
@@ -275,119 +264,130 @@ describe "OM::XML::TermValueOperators" do
           <ns3:roleTerm type="code" authority="marcrelator">cre</ns3:roleTerm>
       </ns3:role>
   <ns3:affiliation>my new value</ns3:affiliation><ns3:affiliation>another new value</ns3:affiliation></ns3:name>'
-      
-	    @sample.term_values_append(
+    end
+
+    it "looks up the parent using :parent_select, uses :parent_index to choose the parent node from the result set, uses :template to build the node(s) to be inserted, inserts the :values(s) into the node(s) and adds the node(s) to the parent" do
+      @sample.term_values_append(
         :parent_select => [:person, {:first_name=>"Tim", :last_name=>"Berners-Lee"}] ,
         :parent_index => :first,
         :template => [:person, :affiliation],
-        :values => ["my new value", "another new value"] 
-      ).to_xml.should == expected_result
-      
-      @sample.find_by_terms(:person, {:first_name=>"Tim", :last_name=>"Berners-Lee"}).first.to_xml.should == expected_result
+        :values => ["my new value", "another new value"]
+      )
     end
-    
+
+    it "should accept parent_select and template [term_reference, find_by_terms_and_value_opts] as argument arrays for generators/find_by_terms_and_values" do
+      # this appends two affiliation nodes into the first person node whose name is Tim Berners-Lee
+      expect(@sample.term_values_append(
+        :parent_select => [:person, {:first_name=>"Tim", :last_name=>"Berners-Lee"}] ,
+        :parent_index => :first,
+        :template => [:person, :affiliation],
+        :values => ["my new value", "another new value"]
+      ).to_xml).to eq(@expected_result)
+
+      expect(@sample.find_by_terms(:person, {:first_name=>"Tim", :last_name=>"Berners-Lee"}).first.to_xml).to eq(@expected_result)
+    end
+
     it "should support adding attribute values" do
       pointer = [{:title_info=>0}, :language]
       test_val = "language value"
-      @article.term_values_append( 
+      @article.term_values_append(
         :parent_select => [{:title_info=>0}],
         :parent_index => 0,
         :template => [{:title_info=>0}, :language],
         :values => test_val
       )
-      @article.term_values(*pointer).first.should == test_val
+      expect(@article.term_values(*pointer).first).to eq(test_val)
     end
-    
+
     it "should accept symbols as arguments for generators/find_by_terms_and_values" do
       # this appends a role of "my role" into the third "person" node in the document
       @sample.term_values_append(
-        :parent_select => :person ,
+        :parent_select => :person,
         :parent_index => 3,
         :template => :role,
-        :values => "my role" 
-      ).to_xml.should #== expected_result
-      @sample.find_by_terms(:person)[3].search("./ns3:role[3]").first.text.should == "my role" 
+        :values => "my role"
+      )
+      expect(@sample.find_by_terms(:person)[3].search("./ns3:role[3]").first.text).to eq("my role")
     end
-    
+
     it "should accept parent_select as an (xpath) string and template as a (template) string" do
       # this uses the provided template to add a node into the first node resulting from the xpath '//oxns:name[@type="personal"]'
       expected_result = "<ns3:name type=\"personal\">\n      <ns3:namePart type=\"family\">Berners-Lee</ns3:namePart>\n      <ns3:namePart type=\"given\">Tim</ns3:namePart>\n      <ns3:role>\n          <ns3:roleTerm type=\"text\" authority=\"marcrelator\">creator</ns3:roleTerm>\n          <ns3:roleTerm type=\"code\" authority=\"marcrelator\">cre</ns3:roleTerm>\n      </ns3:role>\n  <ns3:role type=\"code\" authority=\"marcrelator\"><ns3:roleTerm>creator</ns3:roleTerm></ns3:role></ns3:name>"
-      
-      @sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role', @sample.ox_namespaces).length.should == 1
-      
+
+      expect(@sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role', @sample.ox_namespaces).length).to eq(1)
+
       @sample.term_values_append(
         :parent_select =>'//oxns:name[@type="personal"]',
         :parent_index => 0,
         :template => 'xml.role { xml.roleTerm( \'#{builder_new_value}\', :type=>\'code\', :authority=>\'marcrelator\') }',
-        :values => "founder" 
+        :values => "founder"
       )
 
-      @sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role', @sample.ox_namespaces).length.should == 2
-      @sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role[last()]/oxns:roleTerm', @sample.ox_namespaces).first.text.should == "founder"
+      expect(@sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role', @sample.ox_namespaces).length).to eq(2)
+      expect(@sample.ng_xml.xpath('//oxns:name[@type="personal" and position()=1]/oxns:role[last()]/oxns:roleTerm', @sample.ox_namespaces).first.text).to eq("founder")
 
       # @sample.find_by_terms_and_value(:person).first.to_xml.should == expected_result
     end
-	  
-	  it "should support more complex mixing & matching" do
-	    skip "not working because builder_template is not returning the correct template (returns builder for role instead of roleTerm)"
-      @sample.ng_xml.xpath('//oxns:name[@type="personal"][2]/oxns:role[1]/oxns:roleTerm', @sample.ox_namespaces).length.should == 2
-	    @sample.term_values_append(
+
+    it "should support more complex mixing & matching" do
+      skip "not working because builder_template is not returning the correct template (returns builder for role instead of roleTerm)"
+      expect(@sample.ng_xml.xpath('//oxns:name[@type="personal"][2]/oxns:role[1]/oxns:roleTerm', @sample.ox_namespaces).length).to eq(2)
+      @sample.term_values_append(
         :parent_select =>'//oxns:name[@type="personal"][2]/oxns:role',
         :parent_index => 0,
         :template => [ :person, :role, :text, {:attributes=>{"authority"=>"marcrelator"}} ],
-        :values => "foo" 
+        :values => "foo"
       )
 
-      @sample.ng_xml.xpath('//oxns:name[@type="personal"][2]/oxns:role[1]/oxns:roleTerm', @sample.ox_namespaces).length.should == 3
-      @sample.find_by_terms({:person=>1},:role)[0].search("./oxns:roleTerm[@type=\"text\" and @authority=\"marcrelator\"]", @sample.ox_namespaces).first.text.should == "foo"
-	  end
-	  
-  	it "should create the necessary ancestor nodes when you insert a new term value" do
-  	  @sample.find_by_terms(:person).length.should == 4
-  	  @sample.term_values_append(
-        :parent_select => :person ,
+      expect(@sample.ng_xml.xpath('//oxns:name[@type="personal"][2]/oxns:role[1]/oxns:roleTerm', @sample.ox_namespaces).length).to eq(3)
+      expect(@sample.find_by_terms({:person=>1},:role)[0].search("./oxns:roleTerm[@type=\"text\" and @authority=\"marcrelator\"]", @sample.ox_namespaces).first.text).to eq("foo")
+    end
+
+    it "should create the necessary ancestor nodes when you insert a new term value" do
+      expect(@sample.find_by_terms(:person).length).to eq(4)
+      @sample.term_values_append(
+        :parent_select => :person,
         :parent_index => 8,
         :template => :role,
-        :values => "my role" 
+        :values => "my role"
       )
       person_entries = @sample.find_by_terms(:person)
-      person_entries.length.should == 5
-      person_entries[4].search("./ns3:role").first.text.should == "my role" 
-	  end
-	  
-	  it "should create the necessary ancestor nodes for deep trees of ancestors" do
-  	  deep_pointer = [{:journal=>0}, {:issue=>3}, :pages, :start]
-  	  @article.find_by_terms({:journal=>0}).length.should == 1
-  	  @article.find_by_terms({:journal=>0}, :issue).length.should == 1
-  	  @article.term_values_append(
+      expect(person_entries.length).to eq(5)
+      expect(person_entries[4].search("./ns3:role").first.text).to eq("my role")
+    end
+
+    it "should create the necessary ancestor nodes for deep trees of ancestors" do
+      deep_pointer = [{:journal=>0}, {:issue=>3}, :pages, :start]
+      expect(@article.find_by_terms({:journal=>0}).length).to eq(1)
+      expect(@article.find_by_terms({:journal=>0}, :issue).length).to eq(1)
+      @article.term_values_append(
         :parent_select => deep_pointer[0..deep_pointer.length-2] ,
         :parent_index => 0,
         :template => deep_pointer,
-        :values => "451" 
+        :values => "451"
       )
-      @article.find_by_terms({:journal=>0}, :issue).length.should == 2
-      @article.find_by_terms({:journal=>0}, {:issue=>1}, :pages).length.should == 1
-      @article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).length.should == 1
-      @article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).first.text.should == "451"
-      
-	  end
-	  
-  end
-  
-  describe ".term_value_update" do
-    
-    it "should accept an xpath as :parent_select" do
-	    sample_xpath = '//oxns:name[@type="personal"][4]/oxns:role/oxns:roleTerm[@type="text"]'
-	    @sample.term_value_update(sample_xpath,1,"artist")
-      @sample.ng_xml.xpath(sample_xpath, @sample.ox_namespaces)[1].text.should == "artist"
+      expect(@article.find_by_terms({:journal=>0}, :issue).length).to eq(2)
+      expect(@article.find_by_terms({:journal=>0}, {:issue=>1}, :pages).length).to eq(1)
+      expect(@article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).length).to eq(1)
+      expect(@article.find_by_terms({:journal=>0}, {:issue=>1}, :pages, :start).first.text).to eq("451")
+
     end
-    
+  end
+
+  describe ".term_value_update" do
+
+    it "should accept an xpath as :parent_select" do
+      sample_xpath = '//oxns:name[@type="personal"][4]/oxns:role/oxns:roleTerm[@type="text"]'
+      @sample.term_value_update(sample_xpath,1,"artist")
+      expect(@sample.ng_xml.xpath(sample_xpath, @sample.ox_namespaces)[1].text).to eq("artist")
+    end
+
     it "if :select is provided, should update the first node provided by that xpath statement" do
       sample_xpath = '//oxns:name[@type="personal"][1]/oxns:namePart[@type="given"]'
       @sample.term_value_update(sample_xpath,0,"Timmeh")
-      @sample.ng_xml.xpath(sample_xpath, @sample.ox_namespaces).first.text.should == "Timmeh"
+      expect(@sample.ng_xml.xpath(sample_xpath, @sample.ox_namespaces).first.text).to eq("Timmeh")
     end
-    
+
     it "should replace the existing node if you pass a template and values" do
       skip
       @sample.term_value_update(
@@ -396,72 +396,72 @@ describe "OM::XML::TermValueOperators" do
         :template => [ :person, :role, {:attributes=>{"type"=>"code", "authority"=>"marcrelator"}} ],
         :value => "foo"
       )
-      1.should == 2
+      expect(1).to eq(2)
     end
     it "should delete nodes if value is :delete or nil" do
       @article.update_values([:title_info]=>["york", "mangle","mork"])
       xpath = @article.class.terminology.xpath_for(:title_info)
-      
+
       @article.term_value_update([:title_info], 1, nil)
-      @article.term_values(:title_info).should == ['york', 'mork']
-      
+      expect(@article.term_values(:title_info)).to eq(['york', 'mork'])
+
       @article.term_value_update([:title_info], 1, :delete)
-      @article.term_values(:title_info).should == ['york']
+      expect(@article.term_values(:title_info)).to eq(['york'])
     end
     it "should create empty nodes if value is empty string" do
       @article.update_values([:title_info]=>["york", '', "mork"])
-      @article.term_values(:title_info).should == ['york', "", "mork"]
+      expect(@article.term_values(:title_info)).to eq(['york', "", "mork"])
     end
   end
-  
+
   describe ".term_value_delete" do
     it "should accept an xpath query as :select option" do
-      generic_xpath = '//oxns:name[@type="personal" and position()=4]/oxns:role'
+      generic_xpath  = '//oxns:name[@type="personal" and position()=4]/oxns:role'
       specific_xpath = '//oxns:name[@type="personal" and position()=4]/oxns:role[oxns:roleTerm="visionary"]'
-      select_xpath = '//oxns:name[@type="personal" and position()=4]/oxns:role[last()]'
-      
+      select_xpath   = '//oxns:name[@type="personal" and position()=4]/oxns:role[last()]'
+
       # Check that we're starting with 2 roles
       # Check that the specific node we want to delete exists
-      @sample.find_by_terms_and_value(generic_xpath).length.should == 2
-      @sample.find_by_terms_and_value(specific_xpath).length.should == 1
+      expect(@sample.find_by_terms_and_value(generic_xpath).length).to eq(2)
+      expect(@sample.find_by_terms_and_value(specific_xpath).length).to eq(1)
 
       @sample.term_value_delete(
         :select =>select_xpath
       )
       # Check that we're finishing with 1 role
-      @sample.find_by_terms_and_value(generic_xpath).length.should == 1
+      expect(@sample.find_by_terms_and_value(generic_xpath).length).to eq(1)
       # Check that the specific node we want to delete no longer exists
-      @sample.find_by_terms_and_value(specific_xpath).length.should == 0
-    end 
+      expect(@sample.find_by_terms_and_value(specific_xpath).length).to eq(0)
+    end
     it "should accept :parent_select, :parent_index and :parent_index options instead of a :select" do
-            
+
       generic_xpath = '//oxns:name[@type="personal" and position()=4]/oxns:role/oxns:roleTerm'
       specific_xpath = '//oxns:name[@type="personal" and position()=4]/oxns:role[oxns:roleTerm="visionary"]'
-      
+
       # Check that we're starting with 2 roles
       # Check that the specific node we want to delete exists
-      @sample.find_by_terms_and_value(generic_xpath).length.should == 4
-      @sample.find_by_terms_and_value(specific_xpath).length.should == 1
+      expect(@sample.find_by_terms_and_value(generic_xpath).length).to eq(4)
+      expect(@sample.find_by_terms_and_value(specific_xpath).length).to eq(1)
 
-      # this is attempting to delete the last child (in this case roleTerm) from the 3rd role in the document. 
+      # this is attempting to delete the last child (in this case roleTerm) from the 3rd role in the document.
       @sample.term_value_delete(
         :parent_select => [:person, :role],
         :parent_index => 3,
         :child_index => :last
       )
-      
+
       # Check that we're finishing with 1 role
-      @sample.find_by_terms_and_value(generic_xpath).length.should == 3
+      expect(@sample.find_by_terms_and_value(generic_xpath).length).to eq(3)
       # Check that the specific node we want to delete no longer exists
-      @sample.find_by_terms_and_value(specific_xpath).length.should == 1
+      expect(@sample.find_by_terms_and_value(specific_xpath).length).to eq(1)
     end
     it "should work if only :parent_select and :parent_index are provided" do
       generic_xpath = '//oxns:name[@type="personal"]/oxns:role'
       # specific_xpath = '//oxns:name[@type="personal"]/oxns:role'
-      
+
       # Check that we're starting with 2 roles
       # Check that the specific node we want to delete exists
-      @sample.find_by_terms_and_value(generic_xpath).length.should == 4
+      expect(@sample.find_by_terms_and_value(generic_xpath).length).to eq(4)
       # @sample.find_by_terms_and_value(specific_xpath).length.should == 1
 
       @sample.term_value_delete(
@@ -469,14 +469,14 @@ describe "OM::XML::TermValueOperators" do
         :child_index => 3
       )
       # Check that we're finishing with 1 role
-      @sample.find_by_terms_and_value(generic_xpath).length.should == 3
+      expect(@sample.find_by_terms_and_value(generic_xpath).length).to eq(3)
     end
   end
-  
+
   describe "build_ancestors" do
     it "should raise an error if it cant find a starting point for building from" do
-      lambda { @empty_sample.build_ancestors( [:journal, :issue], 0) }.should raise_error(OM::XML::TemplateMissingException, "Cannot insert nodes into the document because it is empty.  Try defining self.xml_template on the OM::Samples::ModsArticle class.") 
+      expect { @empty_sample.build_ancestors( [:journal, :issue], 0) }.to raise_error(OM::XML::TemplateMissingException, "Cannot insert nodes into the document because it is empty.  Try defining self.xml_template on the OM::Samples::ModsArticle class.")
     end
   end
-  
+
 end

--- a/spec/unit/term_xpath_generator_spec.rb
+++ b/spec/unit/term_xpath_generator_spec.rb
@@ -34,13 +34,13 @@ describe "OM::XML::TermXpathGeneratorSpec" do
 
   describe "generate_xpath" do
     it "should generate an xpath based on the given mapper and options" do
-      OM::XML::TermXpathGenerator.should_receive(:generate_absolute_xpath).with(@test_term)
+      expect(OM::XML::TermXpathGenerator).to receive(:generate_absolute_xpath).with(@test_term)
       OM::XML::TermXpathGenerator.generate_xpath(@test_term, :absolute)
 
-      OM::XML::TermXpathGenerator.should_receive(:generate_relative_xpath).with(@test_term)
+      expect(OM::XML::TermXpathGenerator).to receive(:generate_relative_xpath).with(@test_term)
       OM::XML::TermXpathGenerator.generate_xpath(@test_term, :relative)
 
-      OM::XML::TermXpathGenerator.should_receive(:generate_constrained_xpath).with(@test_term)
+      expect(OM::XML::TermXpathGenerator).to receive(:generate_constrained_xpath).with(@test_term)
       OM::XML::TermXpathGenerator.generate_xpath(@test_term, :constrained)
     end
   end
@@ -137,7 +137,7 @@ EOF
       expect(@sample_terminology.xpath_with_indexes(:name, {:family_name=>1},{})).to eq '//oxns:name/oxns:namePart[@type="family"][2]'
     end
     it "should warn about indexes on a proxy" do
-      Logger.any_instance.should_receive(:warn).with("You attempted to call an index value of 1 on the term \":family_name\". However \":family_name\" is a proxy so we are ignoring the index. See https://jira.duraspace.org/browse/HYDRA-643")
+      expect_any_instance_of(Logger).to receive(:warn).with("You attempted to call an index value of 1 on the term \":family_name\". However \":family_name\" is a proxy so we are ignoring the index. See https://jira.duraspace.org/browse/HYDRA-643")
       expect(@sample_terminology.xpath_with_indexes({:family_name=>1})).to eq "//oxns:name/oxns:namePart[@type=\"family\"]"
     end
   end

--- a/spec/unit/terminology_spec.rb
+++ b/spec/unit/terminology_spec.rb
@@ -189,7 +189,7 @@ describe "OM::XML::Terminology" do
   describe '#to_xml' do
     it "should let you serialize mappings to an xml document" do
       skip
-      TerminologyTest.to_xml.should == ""
+      expect(TerminologyTest.to_xml).to eq("")
     end
   end
 
@@ -209,8 +209,8 @@ describe "OM::XML::Terminology" do
   describe ".retrieve_term" do
     it "should return the mapper identified by the given pointer" do
       term = @test_terminology.retrieve_term(:name, :namePart)
-      expect(term.should).to eq @test_terminology.terms[:name].children[:namePart]
-      expect(term.should).to eq @test_child_term
+      expect(term).to eq @test_terminology.terms[:name].children[:namePart]
+      expect(term).to eq @test_child_term
     end
     it "should build complete terminologies" do
       expect(@test_full_terminology.retrieve_term(:name, :date)).to be_instance_of OM::XML::Term
@@ -292,7 +292,7 @@ describe "OM::XML::Terminology" do
 
   describe ".xpath_with_indexes" do
     it "should return the xpath given in the call to #accessor" do
-      @test_full_terminology.xpath_with_indexes( :title_info ).should == '//oxns:titleInfo'
+      expect(@test_full_terminology.xpath_with_indexes( :title_info )).to eq('//oxns:titleInfo')
     end
     it "should support xpath queries as argument" do
       expect(@test_full_terminology.xpath_with_indexes('//oxns:name[@type="personal"][1]/oxns:namePart')).to eq '//oxns:name[@type="personal"][1]/oxns:namePart'

--- a/spec/unit/validation_spec.rb
+++ b/spec/unit/validation_spec.rb
@@ -33,14 +33,14 @@ describe "OM::XML::Validation" do
   describe "#validate" do
     it "should validate the provided document against the schema provided in class definition  -- fails if no internet connection" do
       skip "no internet connection"
-      ValidationTest.schema.should_receive(:validate).with(@sample).and_return([])
+      expect(ValidationTest.schema).to receive(:validate).with(@sample).and_return([])
       ValidationTest.validate(@sample)
     end
   end
 
   describe ".validate" do
     it "should rely on class validate method" do
-      ValidationTest.should_receive(:validate).with(@sample)
+      expect(ValidationTest).to receive(:validate).with(@sample)
       @sample.validate
     end
   end
@@ -56,7 +56,7 @@ describe "OM::XML::Validation" do
   
     it "should lazy load the schema file from the @schema_url" do
       expect(ValidationTest.instance_variable_get(:@schema_file)).to be_nil
-      ValidationTest.should_receive(:file_from_url).with(ValidationTest.schema_url).once.and_return("fake file")
+      expect(ValidationTest).to receive(:file_from_url).with(ValidationTest.schema_url).once.and_return("fake file")
       ValidationTest.schema_file
       expect(ValidationTest.instance_variable_get(:@schema_file)).to eq "fake file"
       expect(ValidationTest.schema_file).to eq "fake file"
@@ -65,7 +65,7 @@ describe "OM::XML::Validation" do
 
   describe "#file_from_url" do
     it "should retrieve a file from the provided url over HTTP" do
-      ValidationTest.should_receive(:open).with("http://google.com")
+      expect(ValidationTest).to receive(:open).with("http://google.com")
       ValidationTest.send(:file_from_url, "http://google.com")
     end
     it "should raise an error if the url is invalid" do

--- a/spec/unit/xml_serialization_spec.rb
+++ b/spec/unit/xml_serialization_spec.rb
@@ -13,7 +13,7 @@ describe "OM::XML::Terminology.to_xml" do
   it "should call .to_xml on all of the terms" do
     options = {}
     doc = Nokogiri::XML::Document.new
-    @terminology.terms.values.each {|term| term.should_receive(:to_xml) }
+    @terminology.terms.values.each {|term| expect(term).to receive(:to_xml) }
     @terminology.to_xml(options,doc)
   end
 end
@@ -41,7 +41,7 @@ describe "OM::XML::Term.to_xml" do
   end
   it "should capture root term info" do
     xml = @terminology.root_terms.first.to_xml
-    xml.xpath("/term/is_root_term").text.should == "true"
+    expect(xml.xpath("/term/is_root_term").text).to eq("true")
     expect(@person_first_name.to_xml.xpath("/term/is_root_term")).to be_empty
   end
   it "should allow you to pass in a document to add the term to" do
@@ -50,7 +50,7 @@ describe "OM::XML::Term.to_xml" do
   end
   it "should include children" do
     children = @person.to_xml.xpath("//term[@name=\"person\"]/children/*")
-    children.length.should == 12
+    expect(children.length).to eq(12)
     children.each {|child| expect(child.name).to eq "term"}
   end
   it "should skip children if :children=>false" do

--- a/spec/unit/xml_terminology_based_solrizer_spec.rb
+++ b/spec/unit/xml_terminology_based_solrizer_spec.rb
@@ -30,7 +30,7 @@ describe OM::XML::TerminologyBasedSolrizer do
       @mods_article.field_mapper = Solrizer::FieldMapper.new
       Samples::ModsArticle.terminology.terms.each_pair do |k,v|
         next if k == :mods # we don't index the root node
-        @mods_article.should_receive(:solrize_term).with(v, solr_doc, @mods_article.field_mapper)
+        expect(@mods_article).to receive(:solrize_term).with(v, solr_doc, @mods_article.field_mapper)
       end
       @mods_article.to_solr(solr_doc)
     end


### PR DESCRIPTION
Hand corrected 3 examples including skipping one that was never properly
implemented.

This conversion is done by Transpec 2.3.8 with the following command:
    transpec

* 59 conversions
    from: obj.should
      to: expect(obj).to

* 49 conversions
    from: == expected
      to: eq(expected)

* 25 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 5 conversions
    from: lambda { }.should
      to: expect { }.to

* 4 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 2 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 1 conversion
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

* 1 conversion
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions